### PR TITLE
Add models and migrations for claims and speakers

### DIFF
--- a/config/sequelize-config.js
+++ b/config/sequelize-config.js
@@ -6,13 +6,22 @@ module.exports = {
   development: {
     url: process.env.DATABASE_URL_DEVELOPMENT || '',
     dialect: 'postgres',
+    define: {
+      underscored: true,
+    },
   },
   test: {
     url: process.env.DATABASE_URL_TEST || '',
     dialect: 'postgres',
+    define: {
+      underscored: true,
+    },
   },
   production: {
     url: process.env.DATABASE_URL_PRODUCTION || '',
     dialect: 'postgres',
+    define: {
+      underscored: true,
+    },
   },
 }

--- a/src/server/migrations/20190516164909-create-claim.js
+++ b/src/server/migrations/20190516164909-create-claim.js
@@ -1,0 +1,31 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('claims', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER,
+    },
+    content: {
+      type: Sequelize.TEXT,
+    },
+    claimed_at: {
+      type: Sequelize.DATE,
+    },
+    source_url: {
+      type: Sequelize.STRING(1024),
+    },
+    claim_buster_score: {
+      type: Sequelize.FLOAT,
+    },
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+  }),
+  down: queryInterface => queryInterface.dropTable('claims'),
+}

--- a/src/server/migrations/20190516182547-create-speaker.js
+++ b/src/server/migrations/20190516182547-create-speaker.js
@@ -1,0 +1,22 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('speakers', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER,
+    },
+    full_name: {
+      type: Sequelize.STRING,
+    },
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+  }),
+  down: queryInterface => queryInterface.dropTable('speakers'),
+}

--- a/src/server/migrations/20190516183038-associate-claim-and-speaker.js
+++ b/src/server/migrations/20190516183038-associate-claim-and-speaker.js
@@ -1,0 +1,20 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn(
+    'claims',
+    'speaker_id',
+    {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'speakers',
+        key: 'id',
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'SET NULL',
+    },
+  ),
+
+  down: queryInterface => queryInterface.removeColumn(
+    'claims',
+    'speaker_id',
+  ),
+}

--- a/src/server/models/claim.js
+++ b/src/server/models/claim.js
@@ -1,0 +1,14 @@
+module.exports = (sequelize, DataTypes) => {
+  const Claim = sequelize.define('Claim', {
+    content: DataTypes.TEXT,
+    claimedAt: DataTypes.DATE,
+    sourceUrl: DataTypes.STRING(1024),
+    claimBusterScore: DataTypes.FLOAT,
+  }, {})
+  Claim.associate = (models) => {
+    Claim.belongsTo(models.Speaker, {
+      as: 'speaker',
+    })
+  }
+  return Claim
+}

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -1,0 +1,47 @@
+import fs from 'fs'
+import path from 'path'
+import Sequelize from 'sequelize'
+import config from '../../../config/sequelize-config'
+
+const env = process.env.NODE_ENV || 'development'
+const envConfig = config[env]
+
+const db = {}
+const sequelize = new Sequelize(envConfig.url, envConfig)
+
+const getModelFiles = () => {
+  const isFileVisible = file => file.indexOf('.') !== 0
+  const isFileDifferentFromThisFile = file => file !== path.basename(__filename)
+  const isFileJavaScript = file => file.slice(-3) === '.js'
+
+  return fs
+    .readdirSync(__dirname)
+    .filter(file => (
+      isFileVisible(file) && isFileDifferentFromThisFile(file) && isFileJavaScript(file)))
+}
+
+// Uses the `db` and `sequelize` variables defined above thanks to lexical scoping
+const registerModels = (modelFiles) => {
+  modelFiles.forEach((modelFile) => {
+    const model = sequelize.import(path.join(__dirname, modelFile))
+    db[model.name] = model
+  })
+}
+
+// Uses the `db` variable defined above thanks to lexical scoping
+const registerModelAssociations = () => {
+  Object.keys(db).forEach((modelName) => {
+    if (db[modelName].associate) {
+      db[modelName].associate(db)
+    }
+  })
+}
+
+const modelFiles = getModelFiles()
+registerModels(modelFiles)
+registerModelAssociations()
+
+db.sequelize = sequelize
+db.Sequelize = Sequelize
+
+module.exports = db

--- a/src/server/models/speaker.js
+++ b/src/server/models/speaker.js
@@ -1,0 +1,11 @@
+module.exports = (sequelize, DataTypes) => {
+  const Speaker = sequelize.define('Speaker', {
+    fullName: DataTypes.STRING,
+  }, {})
+  Speaker.associate = (models) => {
+    Speaker.hasMany(models.Claim, {
+      as: 'claims',
+    })
+  }
+  return Speaker
+}

--- a/src/server/seeders/20190516191610-demo-speakers-and-claims.js
+++ b/src/server/seeders/20190516191610-demo-speakers-and-claims.js
@@ -1,0 +1,44 @@
+module.exports = {
+  up: async (queryInterface) => {
+    // Generate speakers first, so we have an ID to associate with claims.
+    await queryInterface.bulkInsert('speakers', [
+      {
+        full_name: '[Testing] Ray Boyd',
+        created_at: (new Date()).toISOString(),
+        updated_at: (new Date()).toISOString(),
+      },
+    ], {})
+
+    // Nab the latest speaker ID.
+    const speakers = await queryInterface.sequelize.query("SELECT id FROM speakers WHERE full_name LIKE '[Testing]%' ORDER BY id DESC LIMIT 1;")
+
+    // Now, generate our claims and associate with the speaker above.
+    return queryInterface.bulkInsert('claims', [
+      {
+        content: '[Testing] The human head weighs eight pounds.',
+        source_url: 'https://www.imdb.com/title/tt0116695/quotes/qt0389281',
+        claim_buster_score: 0.05,
+        claimed_at: (new Date('13 December 1996').toISOString()),
+        speaker_id: speakers[0][0].id,
+        created_at: (new Date()).toISOString(),
+        updated_at: (new Date()).toISOString(),
+      },
+    ], {})
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    const testSpeakers = await queryInterface.sequelize.query("SELECT id FROM speakers WHERE full_name LIKE '[Testing]%';")
+    const testSpeakersIds = testSpeakers[0].map(speaker => speaker.id)
+    // Delete claims first, since they belong to speakers.
+    await queryInterface.bulkDelete('claims', {
+      speaker_id: {
+        [Sequelize.Op.in]: testSpeakersIds,
+      },
+    }, {})
+    await queryInterface.bulkDelete('speakers', {
+      id: {
+        [Sequelize.Op.in]: testSpeakersIds,
+      },
+    }, {})
+  },
+}


### PR DESCRIPTION
Here we’ve got Sequelize models and migrations for claims and speakers, as well as a seed of each. After merging this, you’ll want to run `yarn migrate` and `sequelize db:seed:all` (the latter only if you actually want the seeds in your database, so, *not in production*).

By default, Sequelize camelCases tables and columns for consistency with the models and model attributes themselves, but we like to follow snake-case for SQL and camelCase for JavaScript. So there’s also some stitching here to make that mapping work properly. Just be aware that when referencing SQL field names (such as in migrations and seed files), you’ll want to use the snake-cased names (e.g. `created_at`), while using camelCase (`createdAt`) when referencing Sequelize/JavaScript model names/attributes. It can be weird.

Closes #14