### PR TITLE
Add CNN transcript portal crawler

### DIFF
--- a/src/server/queues/AbstractJobScheduler.js
+++ b/src/server/queues/AbstractJobScheduler.js
@@ -44,13 +44,11 @@ class AbstractJobScheduler {
   })
 
   scheduleJobs = () => this.getQueue().add(
-    this.getScheduleName(),
-    {},
+    this.getJobData(),
     { repeat: this.getRepeatOptions() },
   )
 
   unscheduleJobs = () => this.getQueue().removeRepeatable(
-    this.getScheduleName(),
     this.getRepeatOptions(),
   )
 }

--- a/src/server/queues/AbstractJobScheduler.js
+++ b/src/server/queues/AbstractJobScheduler.js
@@ -21,17 +21,27 @@ class AbstractJobScheduler {
    * Abstract method that provides the queue object that the schedule
    * should be applied to.
    *
+   * OVERRIDE WHEN EXTENDING
+   *
    * @return {Queue} the queue object
    */
   getQueue = () => {
     throw new Error('You extended AbstractJobScheduler but forgot to define getQueue()')
   }
 
+  /**
+   * Method that provides the job information that should be part of the scheduled
+   * task.
+   *
+   * This does not need to be overridden when extending, but can be.
+   *
+   * @return {Object} The object to be passed to the job processor for repeated jobs
+   */
+  getJobData = () => ({})
+
   getRepeatOptions = () => ({
     cron: this.getScheduleCron(),
   })
-
-  getScheduleName = () => `repeating-${this.getQueue().name}`
 
   scheduleJobs = () => this.getQueue().add(
     this.getScheduleName(),

--- a/src/server/queues/cnnTranscriptPortalCrawlerQueue/CnnTranscriptPortalCrawlerJobScheduler.js
+++ b/src/server/queues/cnnTranscriptPortalCrawlerQueue/CnnTranscriptPortalCrawlerJobScheduler.js
@@ -1,0 +1,13 @@
+import CnnTranscriptPortalCrawlerQueueFactory from './CnnTranscriptPortalCrawlerQueueFactory'
+import AbstractJobScheduler from '../AbstractJobScheduler'
+import { Schedules } from '../constants'
+
+const getQueueFactory = () => new CnnTranscriptPortalCrawlerQueueFactory()
+
+class CnnTranscriptPortalCrawlerJobScheduler extends AbstractJobScheduler {
+  getScheduleCron = () => Schedules.EVERY_MINUTE
+
+  getQueue = () => getQueueFactory().getQueue()
+}
+
+export default CnnTranscriptPortalCrawlerJobScheduler

--- a/src/server/queues/cnnTranscriptPortalCrawlerQueue/CnnTranscriptPortalCrawlerQueueFactory.js
+++ b/src/server/queues/cnnTranscriptPortalCrawlerQueue/CnnTranscriptPortalCrawlerQueueFactory.js
@@ -1,0 +1,10 @@
+import { QueueNames } from '../constants'
+import AbstractQueueFactory from '../AbstractQueueFactory'
+
+class CnnTranscriptPortalCrawlerQueueFactory extends AbstractQueueFactory {
+  getQueueName = () => QueueNames.crawlerQueues.CNN_TRANSCRIPT_PORTAL
+
+  getPathToProcessor = () => `${__dirname}/cnnTranscriptPortalCrawlerJobProcessor.js`
+}
+
+export default CnnTranscriptPortalCrawlerQueueFactory

--- a/src/server/queues/cnnTranscriptPortalCrawlerQueue/cnnTranscriptPortalCrawlerJobProcessor.js
+++ b/src/server/queues/cnnTranscriptPortalCrawlerQueue/cnnTranscriptPortalCrawlerJobProcessor.js
@@ -1,0 +1,7 @@
+import { CnnTranscriptPortalCrawler } from '../../workers/crawlers/CnnCrawlers'
+
+export default async () => {
+  const crawler = new CnnTranscriptPortalCrawler()
+  const crawlResults = await crawler.run()
+  return crawlResults
+}

--- a/src/server/queues/cnnTranscriptPortalCrawlerQueue/index.js
+++ b/src/server/queues/cnnTranscriptPortalCrawlerQueue/index.js
@@ -1,0 +1,9 @@
+import CnnTranscriptPortalCrawlerQueueFactory from './CnnTranscriptPortalCrawlerQueueFactory'
+import CnnTranscriptPortalCrawlerJobScheduler from './CnnTranscriptPortalCrawlerJobScheduler'
+import cnnTranscriptPortalCrawlerJobProcessor from './cnnTranscriptPortalCrawlerJobProcessor'
+
+export default {
+  factory: new CnnTranscriptPortalCrawlerQueueFactory(),
+  scheduler: new CnnTranscriptPortalCrawlerJobScheduler(),
+  processor: cnnTranscriptPortalCrawlerJobProcessor,
+}

--- a/src/server/queues/constants.js
+++ b/src/server/queues/constants.js
@@ -8,6 +8,7 @@ export const Schedules = {
 export const QueueNames = {
   crawlerQueues: {
     ABSTRACT: 'abstractCrawler',
+    CNN_TRANSCRIPT_PORTAL: 'cnnTranscriptPortalCrawler',
     HELLO_WORLD: 'helloWorldCrawler',
   },
 }

--- a/src/server/queues/helloWorldCrawlerQueue/helloWorldCrawlerJobProcessor.js
+++ b/src/server/queues/helloWorldCrawlerQueue/helloWorldCrawlerJobProcessor.js
@@ -1,8 +1,6 @@
 import HelloWorldCrawler from '../../workers/crawlers/HelloWorldCrawler'
 
-export default (job) => {
-  console.log('Starting job:')
-  console.log(job)
+export default () => {
   const crawler = new HelloWorldCrawler()
   const crawlResults = crawler.run()
   return Promise.resolve(crawlResults)

--- a/src/server/utils/__test__/crawler.test.js
+++ b/src/server/utils/__test__/crawler.test.js
@@ -1,0 +1,23 @@
+import {
+  extractUrl,
+  extractUrls,
+} from '../crawler'
+
+describe('extractUrl', () => {
+  it('Should extract urls from anchor tags', () => {
+    expect(extractUrl('<a href="google.com"></a>'))
+      .toBe('google.com')
+  })
+})
+
+describe('extractUrls', () => {
+  it('Should extract a single url from an anchor tag', () => {
+    expect(extractUrls('<a href="google.com"></a>'))
+      .toEqual(['google.com'])
+  })
+
+  it('Should extract multiple urls from multiple anchor tags', () => {
+    expect(extractUrls('<a href="google.com"></a><a href="cnn.com"></a>'))
+      .toEqual(['google.com', 'cnn.com'])
+  })
+})

--- a/src/server/utils/crawler.js
+++ b/src/server/utils/crawler.js
@@ -1,0 +1,10 @@
+import cheerio from 'cheerio'
+
+export const extractUrl = elem => cheerio(elem).attr('href')
+
+export const extractUrls = (html) => {
+  const $ = cheerio.load(html)
+  return $('a')
+    .map((i, elem) => extractUrl(elem))
+    .get()
+}

--- a/src/server/workers/crawlers/CnnCrawlers/CnnTranscriptPortalCrawler.js
+++ b/src/server/workers/crawlers/CnnCrawlers/CnnTranscriptPortalCrawler.js
@@ -1,0 +1,15 @@
+import AbstractCrawler from '../AbstractCrawler'
+import { extractUrls } from '../../../utils/crawler'
+
+class CnnTranscriptPortalCrawler extends AbstractCrawler {
+  constructor() {
+    super('http://transcripts.cnn.com/TRANSCRIPTS/')
+  }
+
+  isTranscriptListUrl = url => url.startsWith('/TRANSCRIPTS/')
+
+  crawlHandler = responseString => extractUrls(responseString)
+    .filter(this.isTranscriptListUrl)
+}
+
+export default CnnTranscriptPortalCrawler

--- a/src/server/workers/crawlers/CnnCrawlers/__test__/CnnTranscriptPortalCrawler.test.js
+++ b/src/server/workers/crawlers/CnnCrawlers/__test__/CnnTranscriptPortalCrawler.test.js
@@ -1,0 +1,10 @@
+import AbstractCrawler from '../../AbstractCrawler'
+import CnnTranscriptPortalCrawler from '../CnnTranscriptPortalCrawler'
+
+const crawler = new CnnTranscriptPortalCrawler()
+
+describe('CnnTranscriptPortalCrawler', () => {
+  it('Should extend AbstractCrawler', () => {
+    expect(crawler).toBeInstanceOf(AbstractCrawler)
+  })
+})

--- a/src/server/workers/crawlers/CnnCrawlers/index.js
+++ b/src/server/workers/crawlers/CnnCrawlers/index.js
@@ -1,0 +1,4 @@
+/* eslint-disable import/prefer-default-export */
+// We will have more exports than this, so we don't want to use export default
+
+export { default as CnnTranscriptPortalCrawler } from './CnnTranscriptPortalCrawler'

--- a/src/server/workers/crawlers/HelloWorldCrawler.js
+++ b/src/server/workers/crawlers/HelloWorldCrawler.js
@@ -1,14 +1,12 @@
 import AbstractCrawler from './AbstractCrawler'
+import { extractUrls } from '../../utils/crawler'
 
 class HelloWorldCrawler extends AbstractCrawler {
   constructor() {
     super('https://google.com')
   }
 
-  crawlHandler = (responseString) => {
-    console.log(`Hello, I crawled ${responseString}`)
-    return []
-  }
+  crawlHandler = responseString => extractUrls(responseString)
 }
 
 export default HelloWorldCrawler


### PR DESCRIPTION
CNN publishes transcripts on a continuous basis and has a few types of transcript list.  Specifically they have a transcript list for each day, show, and a special transcript list of "breaking news" transcripts.

All of these lists are linked to from a single transcript portal.

This commit creates the crawler of that portal.  It does not result in a list of transcript URLs but rather it returns a list of transcript list URLs which then need to be passed to a not-yet-written CnnTranscriptListCrawler.

This also kicks off a utils/crawler.js tool which abstracts common compound cheerio tasks that are not unique to specific crawlers.

One other non-breaking change I made to the AbstractCrawlScheduler is to make it possible for a descendant class to override the data passed to the scheduled jobs.  Before this was hard coded to `{}` but now an extending class can override the `getJobData` method to return whatever they might want.

Issue #24