### PR TITLE
Automatically config all process.env variables

### DIFF
--- a/src/server/config.js
+++ b/src/server/config.js
@@ -3,11 +3,10 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 const {
-  REDIS_URL,
   ENABLED_QUEUE_DIRECTORIES,
 } = process.env
 
 export default {
-  REDIS_URL,
+  ...process.env,
   ENABLED_QUEUE_DIRECTORIES: ENABLED_QUEUE_DIRECTORIES.split(','),
 }

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -1,10 +1,12 @@
 import fs from 'fs'
 import path from 'path'
 import Sequelize from 'sequelize'
-import config from '../../../config/sequelize-config'
 
-const env = process.env.NODE_ENV || 'development'
-const envConfig = config[env]
+import config from '../config'
+import sequelizeConfig from '../../../config/sequelize-config'
+
+const env = config.NODE_ENV || 'development'
+const envConfig = sequelizeConfig[env]
 
 const db = {}
 const sequelize = new Sequelize(envConfig.url, envConfig)


### PR DESCRIPTION
Instead of having to manually list any `.env`-set variables that we want added to our own `config` object (see substantially more description in #49), just grab all of `process.env`. Now we don’t have yet another place to add a new environment variable.

Closes #49