### PR TITLE
Add mailer and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,10 @@ REDIS_URL=redis://127.0.0.1:6379
 #
 # A value of `*` will load all queues.
 ENABLED_QUEUE_DIRECTORIES=*
+
+# Mailer settings
+# (Get these from Mailgun)
+MAILER_FROM_ADDRESS='Visible Name <email@address.com>'
+MAILER_API_DOMAIN=domain.org
+MAILER_API_URL=https://api.mailgun.net/v3/domain.org
+MAILER_API_KEY=ABC123

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
-# Database connection strings
-
+# PostgreSQL connection settings
 DATABASE_URL_PRODUCTION=postgresql://username:password@localhost/dbname
 DATABASE_URL_DEVELOPMENT=postgresql://username:password@localhost/dbname
 DATABASE_URL_TEST=postgresql://username:password@localhost/dbname
 
+# Redis connection settings
 REDIS_URL=redis://127.0.0.1:6379
 
 # A comma separated list of queue directories (subdirectories in src/server/queues()

--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,11 @@ REDIS_URL=redis://127.0.0.1:6379
 # A value of `*` will load all queues.
 ENABLED_QUEUE_DIRECTORIES=*
 
-# Mailer settings
-# (Get these from Mailgun)
+# Generic mailer settings
 MAILER_FROM_ADDRESS='Visible Name <email@address.com>'
-MAILER_API_DOMAIN=domain.org
-MAILER_API_URL=https://api.mailgun.net/v3/domain.org
-MAILER_API_KEY=ABC123
+
+# Mailgun-specific settings
+# (Get these from Mailgun)
+MAILGUN_API_DOMAIN=domain.org
+MAILGUN_API_URL=https://api.mailgun.net/v3/domain.org
+MAILGUN_API_KEY=ABC123

--- a/README.md
+++ b/README.md
@@ -23,19 +23,7 @@ This project uses [redis](https://redis.io/) as a data store for queues.  You wi
 
 ### Configure the project
 
-You will need to configure your environment variables.  In production this can be done however your host recommends; in development we recommend using an .env file.
-
-The environment variables used in this project are:
-
-* DATABASE_URL_PRODUCTION :: The full database url to be used in production.
-* DATABASE_URL_DEVELOPMENT :: The full database url to be used in development.
-* DATABASE_URL_TEST :: The full database url to be used in testing.
-* REDIS_URL :: The redis url to be used.
-* ENABLED_QUEUE_DIRECTORIES :: The comma separated list of queue directories that should be loaded when the application starts.  A wildcard (*) will load all valid queues.
-
-Database urls will look something like `postgresql://username:password@localhost/dbname`
-
-A template for the contents of `.env` is provided in `.env.example`.
+You will need to configure your environment variables.  In production this can be done however your host recommends; in development we recommend using an `.env` file. A template for the contents of `.env` is provided in `.env.example`.
 
 ```
 > cp .env.example .env

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "queue:jobs:list": "babel-node -- src/scripts/listScheduledJobs",
     "queue:jobs:schedule": "babel-node -- src/scripts/scheduleJobs",
     "queue:jobs:unschedule": "babel-node -- src/scripts/unscheduleJobs",
-    "queue:jobs:run:cnn-portal-crawler": "babel-node -- src/scripts/runCrawler"
+    "queue:jobs:run:cnn-portal-crawler": "babel-node -- src/scripts/runCrawler",
+    "mailer:send-test": "babel-node -- src/scripts/sendTestEmail"
   },
   "devDependencies": {
     "@babel/core": "^7.4.4",
@@ -42,6 +43,7 @@
     "bull": "^3.9.1",
     "cheerio": "^1.0.0-rc.3",
     "dotenv": "^8.0.0",
+    "mailgun-js": "^0.22.0",
     "pg": "^7.10.0",
     "request": "^2.88.0",
     "request-promise": "^4.2.4",

--- a/src/scripts/sendTestEmail.js
+++ b/src/scripts/sendTestEmail.js
@@ -19,11 +19,11 @@ if (!recipient) {
 
 const sendTestEmail = () => new Promise(() => {
   const mailer = new Mailer()
-  return Promise.resolve(mailer.send({
+  return mailer.send({
     recipient,
     subject: 'This is a test email.',
     body: 'This is the body of the email.',
-  }))
+  })
 })
 sendTestEmail().then(() => {
   process.exit()

--- a/src/scripts/sendTestEmail.js
+++ b/src/scripts/sendTestEmail.js
@@ -1,9 +1,11 @@
 import Mailer from '../server/workers/mailer'
+import { isValidEmailAddressFormat } from '../server/utils/mailer'
 
 const getRecipient = () => {
   const recipientFlag = process.argv.indexOf('-r')
   if (recipientFlag !== -1) {
-    return process.argv[recipientFlag + 1]
+    const recipient = process.argv[recipientFlag + 1]
+    if (isValidEmailAddressFormat(recipient)) return recipient
   }
   return null
 }

--- a/src/scripts/sendTestEmail.js
+++ b/src/scripts/sendTestEmail.js
@@ -1,0 +1,30 @@
+import Mailer from '../server/workers/mailer'
+
+const getRecipient = () => {
+  const recipientFlag = process.argv.indexOf('-r')
+  if (recipientFlag !== -1) {
+    return process.argv[recipientFlag + 1]
+  }
+  return null
+}
+
+const recipient = getRecipient()
+if (!recipient) {
+  console.error('Pass in a valid recipient email address with the -r flag, e.g. `-r test@test.com`')
+  console.error('(The email address must be verified with Mailgun while we are using testing subdomains.)')
+  process.exit()
+}
+
+const sendTestEmail = () => new Promise(() => {
+  const mailer = new Mailer()
+  return Promise.resolve(mailer.send({
+    recipient,
+    subject: 'This is a test email.',
+    body: 'This is the body of the email.',
+  }))
+})
+sendTestEmail().then(() => {
+  process.exit()
+}).catch((error) => {
+  console.error(error)
+})

--- a/src/scripts/sendTestEmail.js
+++ b/src/scripts/sendTestEmail.js
@@ -1,5 +1,6 @@
 import Mailer from '../server/workers/mailer'
 import { isValidEmailAddressFormat } from '../server/utils/mailer'
+import logger from '../server/utils/logger'
 
 const getRecipient = () => {
   const recipientFlag = process.argv.indexOf('-r')
@@ -12,8 +13,7 @@ const getRecipient = () => {
 
 const recipient = getRecipient()
 if (!recipient) {
-  console.error('Pass in a valid recipient email address with the -r flag, e.g. `-r test@test.com`')
-  console.error('(The email address must be verified with Mailgun while we are using testing subdomains.)')
+  logger.error('Pass in a valid and Mailgun-verified email address with the `-r` parameter.')
   process.exit()
 }
 
@@ -28,5 +28,5 @@ const sendTestEmail = () => new Promise(() => {
 sendTestEmail().then(() => {
   process.exit()
 }).catch((error) => {
-  console.error(error)
+  logger.error(error)
 })

--- a/src/server/constants.js
+++ b/src/server/constants.js
@@ -1,0 +1,8 @@
+/* eslint-disable import/prefer-default-export */
+/* This will eventually have more than one item, so we do not want a default export */
+
+export const ENV_NAMES = {
+  DEVELOPMENT: 'development',
+  TEST: 'test',
+  PRODUCTION: 'production',
+}

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -3,9 +3,10 @@ import path from 'path'
 import Sequelize from 'sequelize'
 
 import config from '../config'
+import { ENV_NAMES } from '../constants'
 import sequelizeConfig from '../../../config/sequelize-config'
 
-const env = config.NODE_ENV || 'development'
+const env = config.NODE_ENV || ENV_NAMES.DEVELOPMENT
 const envConfig = sequelizeConfig[env]
 
 const db = {}

--- a/src/server/utils/__test__/index.test.js
+++ b/src/server/utils/__test__/index.test.js
@@ -1,0 +1,21 @@
+import {
+  isTestEnv, isDevelopmentEnv, isProductionEnv,
+} from '..'
+
+describe('utils/index', () => {
+  describe('#isTestEnv', () => {
+    it('Should report that we are in the testing environment', () => {
+      expect(isTestEnv()).toBe(true)
+    })
+  })
+  describe('#isDevelopmentEnv', () => {
+    it('Should report that we are in not in the development environment', () => {
+      expect(isDevelopmentEnv()).toBe(false)
+    })
+  })
+  describe('#isProductionEnv', () => {
+    it('Should report that we are in not in the production environment', () => {
+      expect(isProductionEnv()).toBe(false)
+    })
+  })
+})

--- a/src/server/utils/__test__/mailer.test.js
+++ b/src/server/utils/__test__/mailer.test.js
@@ -1,20 +1,20 @@
 import {
-  isValidEmailAddress,
+  isValidEmailAddressFormat,
   isMessageSendable,
 } from '../mailer'
 
 import testData from '../../workers/mailer/__test__/mailerTestData'
 
 describe('utils/mailer', () => {
-  describe('#isValidEmailAddress', () => {
+  describe('#isValidEmailAddressFormat', () => {
     it('Should approve valid emails', () => {
       testData.recipient.valid.forEach((recipient) => {
-        expect(isValidEmailAddress(recipient)).toBe(true)
+        expect(isValidEmailAddressFormat(recipient)).toBe(true)
       })
     })
     it('Should reject invalid emails', () => {
       testData.recipient.invalid.forEach((recipient) => {
-        expect(isValidEmailAddress(recipient)).toBe(false)
+        expect(isValidEmailAddressFormat(recipient)).toBe(false)
       })
     })
   })

--- a/src/server/utils/__test__/mailer.test.js
+++ b/src/server/utils/__test__/mailer.test.js
@@ -1,0 +1,53 @@
+import {
+  isValidEmailAddress,
+  isMessageSendable,
+} from '../mailer'
+
+import testData from '../../workers/mailer/__test__/mailerTestData'
+
+describe('utils/mailer', () => {
+  describe('#isValidEmailAddress', () => {
+    it('Should approve valid emails', () => {
+      testData.recipient.valid.forEach((recipient) => {
+        expect(isValidEmailAddress(recipient)).toBe(true)
+      })
+    })
+    it('Should reject invalid emails', () => {
+      testData.recipient.invalid.forEach((recipient) => {
+        expect(isValidEmailAddress(recipient)).toBe(false)
+      })
+    })
+  })
+  describe('#isMessageSendable', () => {
+    it('Should approve valid message data', () => {
+      expect(isMessageSendable({
+        recipient: testData.recipient.valid[0],
+        subject: testData.subject.valid[0],
+        body: testData.body.valid[0],
+      })).toBe(true)
+    })
+    it('Should reject invalid message data', () => {
+      testData.recipient.invalid.forEach((recipient) => {
+        expect(isMessageSendable({
+          recipient,
+          subject: testData.subject.valid[0],
+          body: testData.body.valid[0],
+        })).toBe(false)
+      })
+      testData.subject.invalid.forEach((subject) => {
+        expect(isMessageSendable({
+          recipient: testData.recipient.valid[0],
+          subject,
+          body: testData.body.valid[0],
+        })).toBe(false)
+      })
+      testData.body.invalid.forEach((body) => {
+        expect(isMessageSendable({
+          recipient: testData.recipient.valid[0],
+          subject: testData.subject.valid[0],
+          body,
+        })).toBe(false)
+      })
+    })
+  })
+})

--- a/src/server/utils/index.js
+++ b/src/server/utils/index.js
@@ -1,0 +1,6 @@
+import config from '../config'
+import { ENV_NAMES } from '../constants'
+
+export const isDevelopmentEnv = () => config.NODE_ENV === ENV_NAMES.DEVELOPMENT
+export const isTestEnv = () => config.NODE_ENV === ENV_NAMES.TEST
+export const isProductionEnv = () => config.NODE_ENV === ENV_NAMES.PRODUCTION

--- a/src/server/utils/mailer.js
+++ b/src/server/utils/mailer.js
@@ -1,3 +1,5 @@
+import logger from './logger'
+
 export const isValidEmailAddressFormat = (emailAddress) => {
   const re = /^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
   return re.test(String(emailAddress).toLowerCase())
@@ -21,16 +23,14 @@ export const isMessageSendable = (mail) => {
  * not complete Mailgun API interactions. When this mode is enabled, however, mailgun-js runs a
  * noisy logger that logs a bunch of stuff to the console. Since we enable test mode when NODE_ENV
  * reports we're testing, this pollutes our test results with a bunch of unnecessary logging. So,
- * we create a logger that returns a bunch of useful data but doesn't actually log to console.
+ * we create a logger that returns a bunch of useful data but doesn't actually log.
  *
- * @return {object} Currently returns some structured request details, although doesn't need to.
- *                  (As a silent logger, all it needs to do is log them.)
+ * @return {object} Returns some structured request details, although we do nothing with it.
  */
 export const testModeLogger = (httpOptions, payload, form) => {
   const { method, path } = httpOptions
   const hasPayload = !!payload
   const hasForm = !!form
-  // TODO: After this is merged, actually log this with the new logger.
   return {
     method, path, hasPayload, hasForm,
   }

--- a/src/server/utils/mailer.js
+++ b/src/server/utils/mailer.js
@@ -1,10 +1,10 @@
-export const isValidEmailAddress = (emailAddress) => {
+export const isValidEmailAddressFormat = (emailAddress) => {
   const re = /^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
   return re.test(String(emailAddress).toLowerCase())
 }
 
 export const isMessageSendable = (mail) => {
-  const hasValidRecipient = recipient => isValidEmailAddress(recipient)
+  const hasValidRecipient = recipient => isValidEmailAddressFormat(recipient)
   const hasValidSubject = subject => !!subject && typeof subject === 'string'
   const hasValidBody = body => !!body && typeof body === 'string'
 

--- a/src/server/utils/mailer.js
+++ b/src/server/utils/mailer.js
@@ -1,5 +1,3 @@
-import logger from './logger'
-
 export const isValidEmailAddressFormat = (emailAddress) => {
   const re = /^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
   return re.test(String(emailAddress).toLowerCase())

--- a/src/server/utils/mailer.js
+++ b/src/server/utils/mailer.js
@@ -15,15 +15,22 @@ export const isMessageSendable = (mail) => {
   )
 }
 
-// The `mailgun-js` package lets you configure it to run in "test mode", which simulates but does
-// not complete Mailgun API interactions. When this mode is enabled, however, mailgun-js runs a
-// noisy logger that logs a bunch of stuff to the console. Since we enable test mode when NODE_ENV
-// reports we're testing, this pollutes our test results with a bunch of unnecessary logging. So,
-// we create a logger that returns a bunch of useful data but doesn't actually log to console.
+
+/**
+ * The `mailgun-js` package lets you configure it to run in "test mode", which simulates but does
+ * not complete Mailgun API interactions. When this mode is enabled, however, mailgun-js runs a
+ * noisy logger that logs a bunch of stuff to the console. Since we enable test mode when NODE_ENV
+ * reports we're testing, this pollutes our test results with a bunch of unnecessary logging. So,
+ * we create a logger that returns a bunch of useful data but doesn't actually log to console.
+ *
+ * @return {object} Currently returns some structured request details, although doesn't need to.
+ *                  (As a silent logger, all it needs to do is log them.)
+ */
 export const testModeLogger = (httpOptions, payload, form) => {
   const { method, path } = httpOptions
   const hasPayload = !!payload
   const hasForm = !!form
+  // TODO: After this is merged, actually log this with the new logger.
   return {
     method, path, hasPayload, hasForm,
   }

--- a/src/server/utils/mailer.js
+++ b/src/server/utils/mailer.js
@@ -1,0 +1,30 @@
+export const isValidEmailAddress = (emailAddress) => {
+  const re = /^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
+  return re.test(String(emailAddress).toLowerCase())
+}
+
+export const isMessageSendable = (mail) => {
+  const hasValidRecipient = recipient => isValidEmailAddress(recipient)
+  const hasValidSubject = subject => !!subject && typeof subject === 'string'
+  const hasValidBody = body => !!body && typeof body === 'string'
+
+  return (
+    hasValidRecipient(mail.recipient)
+    && hasValidSubject(mail.subject)
+    && hasValidBody(mail.body)
+  )
+}
+
+// The `mailgun-js` package lets you configure it to run in "test mode", which simulates but does
+// not complete Mailgun API interactions. When this mode is enabled, however, mailgun-js runs a
+// noisy logger that logs a bunch of stuff to the console. Since we enable test mode when NODE_ENV
+// reports we're testing, this pollutes our test results with a bunch of unnecessary logging. So,
+// we create a logger that returns a bunch of useful data but doesn't actually log to console.
+export const testModeLogger = (httpOptions, payload, form) => {
+  const { method, path } = httpOptions
+  const hasPayload = !!payload
+  const hasForm = !!form
+  return {
+    method, path, hasPayload, hasForm,
+  }
+}

--- a/src/server/workers/mailer/Mailer.js
+++ b/src/server/workers/mailer/Mailer.js
@@ -1,0 +1,38 @@
+import Mailgun from 'mailgun-js'
+
+import config from '../../config'
+import { isMessageSendable, testModeLogger } from '../../utils/mailer'
+
+class Mailer {
+  constructor() {
+    this.mailgun = Mailgun({
+      apiKey: config.MAILER_API_KEY,
+      domain: config.MAILER_API_DOMAIN,
+      testMode: config.NODE_ENV === 'test',
+      testModeLogger,
+    })
+  }
+
+  send = (message) => {
+    const { mailgun } = this
+
+    if (!isMessageSendable(message)) {
+      throw new Error('Mailer requires a message object with a valid recipient, subject, and body.')
+    }
+
+    const mailgunData = {
+      from: config.MAILER_FROM_ADDRESS,
+      to: message.recipient,
+      subject: message.subject,
+      text: message.body,
+    }
+
+    return mailgun.messages().send(mailgunData, (error, body) => {
+      // TODO: Log (#34) or notify (#35) if things go good or bad.
+      if (error) console.log(`Error: ${error}`)
+      if (body) console.log(body)
+    })
+  }
+}
+
+export default Mailer

--- a/src/server/workers/mailer/Mailer.js
+++ b/src/server/workers/mailer/Mailer.js
@@ -2,6 +2,7 @@ import Mailgun from 'mailgun-js'
 
 import config from '../../config'
 import { isMessageSendable, testModeLogger } from '../../utils/mailer'
+import logger from '../../utils/logger'
 import { isTestEnv } from '../../utils'
 
 class Mailer {
@@ -29,9 +30,8 @@ class Mailer {
     }
 
     return mailgun.messages().send(mailgunData, (error, body) => {
-      // TODO: Log (#34) or notify (#35) if things go good or bad.
-      if (error) console.log(`Error: ${error}`)
-      if (body) console.log(body)
+      if (error) logger.error(error)
+      else if (body) logger.info(body)
     })
   }
 }

--- a/src/server/workers/mailer/Mailer.js
+++ b/src/server/workers/mailer/Mailer.js
@@ -6,8 +6,8 @@ import { isMessageSendable, testModeLogger } from '../../utils/mailer'
 class Mailer {
   constructor() {
     this.mailgun = Mailgun({
-      apiKey: config.MAILER_API_KEY,
-      domain: config.MAILER_API_DOMAIN,
+      apiKey: config.MAILGUN_API_KEY,
+      domain: config.MAILGUN_API_DOMAIN,
       testMode: config.NODE_ENV === 'test',
       testModeLogger,
     })

--- a/src/server/workers/mailer/Mailer.js
+++ b/src/server/workers/mailer/Mailer.js
@@ -2,13 +2,14 @@ import Mailgun from 'mailgun-js'
 
 import config from '../../config'
 import { isMessageSendable, testModeLogger } from '../../utils/mailer'
+import { isTestEnv } from '../../utils'
 
 class Mailer {
   constructor() {
     this.mailgun = Mailgun({
       apiKey: config.MAILGUN_API_KEY,
       domain: config.MAILGUN_API_DOMAIN,
-      testMode: config.NODE_ENV === 'test',
+      testMode: isTestEnv(),
       testModeLogger,
     })
   }

--- a/src/server/workers/mailer/__test__/Mailer.test.js
+++ b/src/server/workers/mailer/__test__/Mailer.test.js
@@ -1,0 +1,56 @@
+import Mailer from '../Mailer'
+
+import testData from './mailerTestData'
+import config from '../../../config'
+
+const mailer = new Mailer()
+
+describe('Mailer', () => {
+  it('Should have mailgun credentials', () => {
+    expect(mailer).toHaveProperty('mailgun')
+    expect({
+      apiKey: mailer.mailgun.apiKey,
+      domain: mailer.mailgun.domain,
+    }).toEqual({
+      apiKey: config.MAILER_API_KEY,
+      domain: config.MAILER_API_DOMAIN,
+    })
+  })
+  it('Should not send without valid message data', () => {
+    testData.recipient.invalid.forEach((recipient) => {
+      expect(() => mailer.send({
+        recipient,
+        subject: testData.subject.valid[0],
+        body: testData.body.valid[0],
+      })).toThrow(Error)
+    })
+    testData.subject.invalid.forEach((subject) => {
+      expect(() => mailer.send({
+        recipient: testData.recipient.valid[0],
+        subject,
+        body: testData.body.valid[0],
+      })).toThrow(Error)
+    })
+    testData.body.invalid.forEach((body) => {
+      expect(() => mailer.send({
+        recipient: testData.recipient.valid[0],
+        subject: testData.subject.valid[0],
+        body,
+      })).toThrow(Error)
+    })
+  })
+  it('Should send with valid message data', (done) => {
+    // This is a pretty weak test. I can't quite marshall Mailgun and mailgun-js to provide a
+    // satisfactory simulation of a valid send, so all we're really doing is ensuring it didn't
+    // absolutely explode. TODO: Improve this.
+    const validSend = () => {
+      mailer.send({
+        recipient: testData.recipient.valid[0],
+        subject: testData.subject.valid[0],
+        body: testData.body.valid[0],
+      })
+      done()
+    }
+    expect(validSend).not.toThrow(Error)
+  })
+})

--- a/src/server/workers/mailer/__test__/Mailer.test.js
+++ b/src/server/workers/mailer/__test__/Mailer.test.js
@@ -12,8 +12,8 @@ describe('Mailer', () => {
       apiKey: mailer.mailgun.apiKey,
       domain: mailer.mailgun.domain,
     }).toEqual({
-      apiKey: config.MAILER_API_KEY,
-      domain: config.MAILER_API_DOMAIN,
+      apiKey: config.MAILGUN_API_KEY,
+      domain: config.MAILGUN_API_DOMAIN,
     })
   })
   it('Should not send without valid message data', () => {

--- a/src/server/workers/mailer/__test__/mailerTestData.js
+++ b/src/server/workers/mailer/__test__/mailerTestData.js
@@ -19,7 +19,7 @@ export default {
     invalid: ['', 1, false],
   },
   body: {
-    valid: ['You are invited by anyone to do anything. You are invited for all time... You are so needed by everyone to do everything You are invited for all time'],
+    valid: ['You are invited by anyone to do anything, you are invited for all time. You are so needed by everyone to do everything, you are invited for all time...'],
     invalid: ['', 1, false],
   },
 }

--- a/src/server/workers/mailer/__test__/mailerTestData.js
+++ b/src/server/workers/mailer/__test__/mailerTestData.js
@@ -1,0 +1,25 @@
+export default {
+  recipient: {
+    valid: [
+      'test@test.com',
+      't@t.co',
+      'first+last@test.com',
+      'first.last@test.com',
+      'test@test.co.uk',
+    ],
+    invalid: [
+      '@test.com',
+      'test@',
+      'test',
+      'test@test',
+    ],
+  },
+  subject: {
+    valid: ['You are invited.'],
+    invalid: ['', 1, false],
+  },
+  body: {
+    valid: ['You are invited by anyone to do anything. You are invited for all time... You are so needed by everyone to do everything You are invited for all time'],
+    invalid: ['', 1, false],
+  },
+}

--- a/src/server/workers/mailer/index.js
+++ b/src/server/workers/mailer/index.js
@@ -1,0 +1,3 @@
+import Mailer from './Mailer'
+
+export default Mailer

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,6 +1114,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.3.tgz#5d8d24e0033fc6393efadc85cb59c1f638095c9a"
   integrity sha512-zkOxCS/fA+3SsdA+9Yun0iANxzhQRiNwTvJSr6N95JhuJ/x27z9G2URx1Jpt3zYFfCGUXZGL5UDxt5eyLE7wgw==
 
+"@types/node@^8.0.7":
+  version "8.10.49"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.49.tgz#f331afc5efed0796798e5591d6e0ece636969b7b"
+  integrity sha512-YX30JVx0PvSmJ3Eqr74fYLGeBxD+C7vIL20ek+GGGLJeUbVYRUW3EzyAXpIRA0K8c8o0UWqR/GwEFYiFoz1T8w==
+
 "@types/q@^1.5.1":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
@@ -1166,6 +1171,13 @@ acorn@^6.0.1, acorn@^6.0.7:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
+
+agent-base@4, agent-base@^4.1.0, agent-base@^4.2.0, agent-base@~4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
+  integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
+  dependencies:
+    es6-promisify "^5.0.0"
 
 ajv@^6.5.5, ajv@^6.9.1:
   version "6.10.0"
@@ -1340,6 +1352,11 @@ ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
+
+ast-types@0.x.x:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.1.tgz#9461428a270c5a27fda44b738dd3bab2e9353003"
+  integrity sha512-b+EeK0WlzrSmpMw5jktWvQGxblpWnvMrV+vOp69RLjzGiHwWV0vgq75DPKtUjppKni3yWwSW8WLGV3Ch/XIWcQ==
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -1709,6 +1726,11 @@ bull@^3.9.1:
     semver "^5.6.0"
     util.promisify "^1.0.0"
     uuid "^3.2.1"
+
+bytes@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
+  integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -2467,6 +2489,13 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-uri-to-buffer@2:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-2.0.1.tgz#ca8f56fe38b1fd329473e9d1b4a9afcd8ce1c045"
+  integrity sha512-OkVVLrerfAKZlW2ZZ3Ve2y65jgiWqBKsTfUIAFbn8nVbPcCZg6l6gikKlEYv0kXcmzqGm6mFq/Jf2vriuEkv8A==
+  dependencies:
+    "@types/node" "^8.0.7"
+
 data-urls@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
@@ -2501,17 +2530,24 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -2575,6 +2611,15 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
+
+degenerator@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/degenerator/-/degenerator-1.0.4.tgz#fcf490a37ece266464d9cc431ab98c5819ced095"
+  integrity sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=
+  dependencies:
+    ast-types "0.x.x"
+    escodegen "1.x.x"
+    esprima "3.x.x"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -2854,6 +2899,18 @@ es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es6-promise@^4.0.3:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.6.tgz#b685edd8258886365ea62b57d30de28fadcd974f"
+  integrity sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
+  dependencies:
+    es6-promise "^4.0.3"
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -2864,7 +2921,7 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-escodegen@^1.8.1, escodegen@^1.9.1:
+escodegen@1.x.x, escodegen@^1.8.1, escodegen@^1.9.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.1.tgz#c485ff8d6b4cdb89e27f4a856e91f118401ca510"
   integrity sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==
@@ -3048,7 +3105,7 @@ espree@^5.0.1:
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
 
-esprima@^3.1.3:
+esprima@3.x.x, esprima@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
   integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
@@ -3287,6 +3344,11 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
+file-uri-to-path@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 filesize@^3.6.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.1.tgz#090bb3ee01b6f801a8a8be99d31710b3422bb317"
@@ -3354,7 +3416,7 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@~2.3.2:
+form-data@^2.3.3, form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
   integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
@@ -3394,6 +3456,14 @@ fsevents@^1.2.7:
   dependencies:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
+
+ftp@~0.3.10:
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/ftp/-/ftp-0.3.10.tgz#9197d861ad8142f3e63d5a83bfe4c59f7330885d"
+  integrity sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=
+  dependencies:
+    readable-stream "1.1.x"
+    xregexp "2.0.0"
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -3445,6 +3515,18 @@ get-stream@^4.0.0:
   integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
   dependencies:
     pump "^3.0.0"
+
+get-uri@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-2.0.3.tgz#fa13352269781d75162c6fc813c9e905323fbab5"
+  integrity sha512-x5j6Ks7FOgLD/GlvjKwgu7wdmMR55iuRHhn8hj/+gA+eSbxQvZ+AEomq+3MgVEZj1vpi738QahGbCCSIDtXtkw==
+  dependencies:
+    data-uri-to-buffer "2"
+    debug "4"
+    extend "~3.0.2"
+    file-uri-to-path "1"
+    ftp "~0.3.10"
+    readable-stream "3"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -3719,7 +3801,7 @@ htmlparser2@^3.9.1, htmlparser2@^3.9.2:
     inherits "^2.0.1"
     readable-stream "^3.1.1"
 
-http-errors@~1.7.2:
+http-errors@1.7.2, http-errors@~1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f"
   integrity sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
@@ -3729,6 +3811,14 @@ http-errors@~1.7.2:
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
+
+http-proxy-agent@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
+  integrity sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==
+  dependencies:
+    agent-base "4"
+    debug "3.1.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -3743,6 +3833,14 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
+https-proxy-agent@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
+  integrity sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^3.1.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
@@ -3822,10 +3920,15 @@ indexof@0.0.1:
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
   integrity sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
 
-inflection@1.12.0:
+inflection@1.12.0, inflection@~1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.12.0.tgz#a200935656d6f5f6bc4dc7502e1aecb703228416"
   integrity sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=
+
+inflection@~1.3.0:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.3.8.tgz#cbd160da9f75b14c3cc63578d4f396784bf3014e"
+  integrity sha1-y9Fg2p91sUw8xjV41POWeEvzAU4=
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -3895,6 +3998,11 @@ ioredis@^4.5.1:
     redis-errors "^1.2.0"
     redis-parser "^3.0.0"
     standard-as-callback "^2.0.1"
+
+ip@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
+  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
 is-absolute-url@^2.0.0:
   version "2.1.0"
@@ -4912,7 +5020,7 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
-lru-cache@^4.0.1, lru-cache@^4.1.5:
+lru-cache@^4.0.1, lru-cache@^4.1.2, lru-cache@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
@@ -4926,6 +5034,21 @@ magic-string@^0.22.4:
   integrity sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==
   dependencies:
     vlq "^0.2.2"
+
+mailgun-js@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/mailgun-js/-/mailgun-js-0.22.0.tgz#128942b5e47a364a470791608852bf68c96b3a05"
+  integrity sha512-a2alg5nuTZA9Psa1pSEIEsbxr1Zrmqx4VkgGCQ30xVh0kIH7Bu57AYILo+0v8QLSdXtCyLaS+KVmdCrQo0uWFA==
+  dependencies:
+    async "^2.6.1"
+    debug "^4.1.0"
+    form-data "^2.3.3"
+    inflection "~1.12.0"
+    is-stream "^1.1.0"
+    path-proxy "~1.0.0"
+    promisify-call "^2.0.2"
+    proxy-agent "^3.0.3"
+    tsscmp "^1.0.6"
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -5193,6 +5316,11 @@ neo-async@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
+
+netmask@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
+  integrity sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -5660,6 +5788,31 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+pac-proxy-agent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-3.0.0.tgz#11d578b72a164ad74bf9d5bac9ff462a38282432"
+  integrity sha512-AOUX9jES/EkQX2zRz0AW7lSx9jD//hQS8wFXBvcnd/J2Py9KaMJMqV/LPqJssj1tgGufotb2mmopGPR15ODv1Q==
+  dependencies:
+    agent-base "^4.2.0"
+    debug "^3.1.0"
+    get-uri "^2.0.0"
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.1"
+    pac-resolver "^3.0.0"
+    raw-body "^2.2.0"
+    socks-proxy-agent "^4.0.1"
+
+pac-resolver@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-3.0.0.tgz#6aea30787db0a891704deb7800a722a7615a6f26"
+  integrity sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==
+  dependencies:
+    co "^4.6.0"
+    degenerator "^1.0.4"
+    ip "^1.1.5"
+    netmask "^1.0.6"
+    thunkify "^2.1.2"
+
 package-json@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
@@ -5843,6 +5996,13 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-proxy@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/path-proxy/-/path-proxy-1.0.0.tgz#18e8a36859fc9d2f1a53b48dee138543c020de5e"
+  integrity sha1-GOijaFn8nS8aU7SN7hOFQ8Ag3l4=
+  dependencies:
+    inflection "~1.3.0"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -6392,6 +6552,13 @@ promise.prototype.finally@^3.1.0:
     es-abstract "^1.9.0"
     function-bind "^1.1.1"
 
+promisify-call@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/promisify-call/-/promisify-call-2.0.4.tgz#d48c2d45652ccccd52801ddecbd533a6d4bd5fba"
+  integrity sha1-1IwtRWUszM1SgB3ey9UzptS9X7o=
+  dependencies:
+    with-callback "^1.0.2"
+
 prompts@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.1.0.tgz#bf90bc71f6065d255ea2bdc0fe6520485c1b45db"
@@ -6413,6 +6580,25 @@ proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
+
+proxy-agent@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-3.1.0.tgz#3cf86ee911c94874de4359f37efd9de25157c113"
+  integrity sha512-IkbZL4ClW3wwBL/ABFD2zJ8iP84CY0uKMvBPk/OceQe/cEjrxzN1pMHsLwhbzUoRhG9QbSxYC+Z7LBkTiBNvrA==
+  dependencies:
+    agent-base "^4.2.0"
+    debug "^3.1.0"
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.1"
+    lru-cache "^4.1.2"
+    pac-proxy-agent "^3.0.0"
+    proxy-from-env "^1.0.0"
+    socks-proxy-agent "^4.0.1"
+
+proxy-from-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+  integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -6513,6 +6699,16 @@ range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
+raw-body@^2.2.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.0.tgz#a1ce6fb9c9bc356ca52e89256ab59059e13d0332"
+  integrity sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==
+  dependencies:
+    bytes "3.1.0"
+    http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
+
 rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -6571,6 +6767,25 @@ read-pkg@^4.0.1:
     parse-json "^4.0.0"
     pify "^3.0.0"
 
+readable-stream@1.1.x:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
+readable-stream@3, readable-stream@^3.1.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
+  integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.3, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
@@ -6583,15 +6798,6 @@ readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
-
-readable-stream@^3.1.1:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
-  integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
 
 readdirp@^2.2.1:
   version "2.2.1"
@@ -7155,6 +7361,11 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
+smart-buffer@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.0.2.tgz#5207858c3815cc69110703c6b94e46c15634395d"
+  integrity sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -7184,6 +7395,22 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
+
+socks-proxy-agent@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz#3c8991f3145b2799e70e11bd5fbc8b1963116386"
+  integrity sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==
+  dependencies:
+    agent-base "~4.2.1"
+    socks "~2.3.2"
+
+socks@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.3.2.tgz#ade388e9e6d87fdb11649c15746c578922a5883e"
+  integrity sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==
+  dependencies:
+    ip "^1.1.5"
+    smart-buffer "4.0.2"
 
 source-map-resolve@^0.5.0:
   version "0.5.2"
@@ -7409,6 +7636,11 @@ string_decoder@^1.0.0, string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -7596,6 +7828,11 @@ through@2, through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
+thunkify@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
+  integrity sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=
+
 timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
@@ -7730,6 +7967,11 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
+tsscmp@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
+  integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -7846,6 +8088,11 @@ unique-string@^1.0.0:
   integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
   dependencies:
     crypto-random-string "^1.0.0"
+
+unpipe@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+  integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
 unquote@~1.1.1:
   version "1.1.1"
@@ -8106,6 +8353,11 @@ winston@^3.2.1:
     triple-beam "^1.3.0"
     winston-transport "^4.3.0"
 
+with-callback@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/with-callback/-/with-callback-1.0.2.tgz#a09629b9a920028d721404fb435bdcff5c91bc21"
+  integrity sha1-oJYpuakgAo1yFAT7Q1vc/1yRvCE=
+
 wkx@^0.4.6:
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/wkx/-/wkx-0.4.6.tgz#228ab592e6457382ea6fb79fc825058d07fce523"
@@ -8177,6 +8429,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xregexp@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-2.0.0.tgz#52a63e56ca0b84a7f3a5f3d61872f126ad7a5943"
+  integrity sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
This creates a generic `Mailer` class that interacts with the Mailgun API using the `mailgun-js` npm package. It also:

* Provides test coverage for `Mailer` and its utilities
* Provides a sample send-email script, called via `yarn mailer:send-test` with an email address provided via the `-r` parameter, e.g. `yarn mailer:send-test -r test@test.com`

Closes #22 