### PR TITLE
Add CNN transcript list crawler

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "migrate": "sequelize db:migrate",
     "queue:jobs:list": "babel-node -- src/scripts/listScheduledJobs",
     "queue:jobs:schedule": "babel-node -- src/scripts/scheduleJobs",
-    "queue:jobs:unschedule": "babel-node -- src/scripts/unscheduleJobs"
+    "queue:jobs:unschedule": "babel-node -- src/scripts/unscheduleJobs",
+    "queue:jobs:run:cnn-portal-crawler": "babel-node -- src/scripts/runCrawler"
   },
   "devDependencies": {
     "@babel/core": "^7.4.4",

--- a/src/scripts/runCrawler.js
+++ b/src/scripts/runCrawler.js
@@ -1,0 +1,7 @@
+import cnnTranscriptPortalCrawlerQueueDict from '../server/queues/cnnTranscriptPortalCrawlerQueue'
+import { getQueueFromQueueDict } from '../server/utils/queue'
+import logger from '../server/utils/logger'
+
+const cnnTranscriptPortalCrawlerQueue = getQueueFromQueueDict(cnnTranscriptPortalCrawlerQueueDict)
+cnnTranscriptPortalCrawlerQueue.add()
+logger.info('The crawler is running; you will have to manually exit this process.')

--- a/src/server/queues/cnnTranscriptListCrawlerQueue/CnnTranscriptListCrawlerJobScheduler.js
+++ b/src/server/queues/cnnTranscriptListCrawlerQueue/CnnTranscriptListCrawlerJobScheduler.js
@@ -1,0 +1,13 @@
+import CnnTranscriptListCrawlerQueueFactory from './CnnTranscriptListCrawlerQueueFactory'
+import AbstractJobScheduler from '../AbstractJobScheduler'
+import { Schedules } from '../constants'
+
+const getQueueFactory = () => new CnnTranscriptListCrawlerQueueFactory()
+
+class CnnTranscriptListCrawlerJobScheduler extends AbstractJobScheduler {
+  getScheduleCron = () => Schedules.None
+
+  getQueue = () => getQueueFactory().getQueue()
+}
+
+export default CnnTranscriptListCrawlerJobScheduler

--- a/src/server/queues/cnnTranscriptListCrawlerQueue/CnnTranscriptListCrawlerQueueFactory.js
+++ b/src/server/queues/cnnTranscriptListCrawlerQueue/CnnTranscriptListCrawlerQueueFactory.js
@@ -1,0 +1,10 @@
+import { QueueNames } from '../constants'
+import AbstractQueueFactory from '../AbstractQueueFactory'
+
+class CnnTranscriptListCrawlerQueueFactory extends AbstractQueueFactory {
+  getQueueName = () => QueueNames.crawlerQueues.CNN_TRANSCRIPT_LIST
+
+  getPathToProcessor = () => `${__dirname}/cnnTranscriptListCrawlerJobProcessor.js`
+}
+
+export default CnnTranscriptListCrawlerQueueFactory

--- a/src/server/queues/cnnTranscriptListCrawlerQueue/cnnTranscriptListCrawlerJobProcessor.js
+++ b/src/server/queues/cnnTranscriptListCrawlerQueue/cnnTranscriptListCrawlerJobProcessor.js
@@ -1,0 +1,12 @@
+import { CnnTranscriptListCrawler } from '../../workers/crawlers/CnnCrawlers'
+
+export default async (job) => {
+  const {
+    data: {
+      url,
+    },
+  } = job
+  const crawler = new CnnTranscriptListCrawler(url)
+  const crawlResults = await crawler.run()
+  return crawlResults
+}

--- a/src/server/queues/cnnTranscriptListCrawlerQueue/index.js
+++ b/src/server/queues/cnnTranscriptListCrawlerQueue/index.js
@@ -1,0 +1,9 @@
+import CnnTranscriptListCrawlerQueueFactory from './CnnTranscriptListCrawlerQueueFactory'
+import CnnTranscriptListCrawlerJobScheduler from './CnnTranscriptListCrawlerJobScheduler'
+import cnnTranscriptListCrawlerJobProcessor from './cnnTranscriptListCrawlerJobProcessor'
+
+export default {
+  factory: new CnnTranscriptListCrawlerQueueFactory(),
+  scheduler: new CnnTranscriptListCrawlerJobScheduler(),
+  processor: cnnTranscriptListCrawlerJobProcessor,
+}

--- a/src/server/queues/cnnTranscriptPortalCrawlerQueue/cnnTranscriptPortalCrawlerJobProcessor.js
+++ b/src/server/queues/cnnTranscriptPortalCrawlerQueue/cnnTranscriptPortalCrawlerJobProcessor.js
@@ -1,7 +1,13 @@
 import { CnnTranscriptPortalCrawler } from '../../workers/crawlers/CnnCrawlers'
+import cnnTranscriptListCrawlerQueueDict from '../cnnTranscriptListCrawlerQueue'
+
+const listCrawlerQueue = cnnTranscriptListCrawlerQueueDict.factory.getQueue()
+
+const crawlTranscriptListUrl = url => listCrawlerQueue.add({ url })
 
 export default async () => {
   const crawler = new CnnTranscriptPortalCrawler()
   const crawlResults = await crawler.run()
+  crawlResults.forEach(crawlTranscriptListUrl)
   return crawlResults
 }

--- a/src/server/queues/constants.js
+++ b/src/server/queues/constants.js
@@ -9,6 +9,7 @@ export const QueueNames = {
   crawlerQueues: {
     ABSTRACT: 'abstractCrawler',
     CNN_TRANSCRIPT_PORTAL: 'cnnTranscriptPortalCrawler',
+    CNN_TRANSCRIPT_LIST: 'cnnTranscriptListCrawler',
     HELLO_WORLD: 'helloWorldCrawler',
   },
 }

--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -1,0 +1,44 @@
+import {
+  isTranscriptListUrl,
+  isTranscriptUrl,
+  getFullCnnUrl,
+} from '../cnn'
+
+describe('isTranscriptListUrl', () => {
+  it('Should not improperly identify transcript list urls', () => {
+    expect(isTranscriptListUrl('http://google.com'))
+      .toBe(false)
+  })
+  it('Should identify transcript list urls', () => {
+    expect(isTranscriptListUrl('/TRANSCRIPTS/2019.06.01.html'))
+      .toBe(true)
+  })
+})
+
+describe('isTranscriptUrl', () => {
+  it('Should not improperly identify transcript urls', () => {
+    expect(isTranscriptUrl('http://google.com'))
+      .toBe(false)
+  })
+  it('Should identify transcript list urls', () => {
+    expect(isTranscriptUrl('/TRANSCRIPTS/1906/01/cnr.20.html'))
+      .toBe(true)
+  })
+})
+
+describe('getFullCnnUrl', () => {
+  it('Should not modify a complete url', () => {
+    expect(getFullCnnUrl('http://google.com'))
+      .toBe('http://google.com')
+    expect(getFullCnnUrl('http://cnn.com'))
+      .toBe('http://cnn.com')
+  })
+  it('Should prepend a relative url', () => {
+    expect(getFullCnnUrl('TRANSCRIPTS'))
+      .toBe('http://cnn.com/TRANSCRIPTS')
+  })
+  it('Should prepend a relative url starting with /', () => {
+    expect(getFullCnnUrl('/TRANSCRIPTS'))
+      .toBe('http://cnn.com/TRANSCRIPTS')
+  })
+})

--- a/src/server/utils/cnn.js
+++ b/src/server/utils/cnn.js
@@ -1,0 +1,12 @@
+
+export const isTranscriptListUrl = url => url.startsWith('/TRANSCRIPTS/')
+  && url.endsWith('.html')
+
+export const isTranscriptUrl = url => url.startsWith('/TRANSCRIPTS/')
+  && url.endsWith('.html')
+
+export const getFullCnnUrl = (url) => {
+  if (url.startsWith('http')) return url
+  if (url.startsWith('/')) return `http://cnn.com${url}`
+  return `http://cnn.com/${url}`
+}

--- a/src/server/workers/crawlers/CnnCrawlers/CnnTranscriptListCrawler.js
+++ b/src/server/workers/crawlers/CnnCrawlers/CnnTranscriptListCrawler.js
@@ -1,0 +1,21 @@
+import AbstractCrawler from '../AbstractCrawler'
+import { extractUrls } from '../../../utils/crawler'
+import {
+  isTranscriptListUrl,
+  isTranscriptUrl,
+  getFullCnnUrl,
+} from '../../../utils/cnn'
+
+class CnnTranscriptListCrawler extends AbstractCrawler {
+  constructor(url) {
+    if (!isTranscriptListUrl(url)) {
+      throw new Error('CnnTranscriptListCrawler was passed a URL that does not appear to be a CNN transcript list.')
+    }
+    super(getFullCnnUrl(url))
+  }
+
+  crawlHandler = responseString => extractUrls(responseString)
+    .filter(isTranscriptUrl)
+}
+
+export default CnnTranscriptListCrawler

--- a/src/server/workers/crawlers/CnnCrawlers/CnnTranscriptPortalCrawler.js
+++ b/src/server/workers/crawlers/CnnCrawlers/CnnTranscriptPortalCrawler.js
@@ -1,15 +1,14 @@
 import AbstractCrawler from '../AbstractCrawler'
 import { extractUrls } from '../../../utils/crawler'
+import { isTranscriptListUrl } from '../../../utils/cnn'
 
 class CnnTranscriptPortalCrawler extends AbstractCrawler {
   constructor() {
     super('http://transcripts.cnn.com/TRANSCRIPTS/')
   }
 
-  isTranscriptListUrl = url => url.startsWith('/TRANSCRIPTS/')
-
   crawlHandler = responseString => extractUrls(responseString)
-    .filter(this.isTranscriptListUrl)
+    .filter(isTranscriptListUrl)
 }
 
 export default CnnTranscriptPortalCrawler

--- a/src/server/workers/crawlers/CnnCrawlers/index.js
+++ b/src/server/workers/crawlers/CnnCrawlers/index.js
@@ -1,4 +1,2 @@
-/* eslint-disable import/prefer-default-export */
-// We will have more exports than this, so we don't want to use export default
-
 export { default as CnnTranscriptPortalCrawler } from './CnnTranscriptPortalCrawler'
+export { default as CnnTranscriptListCrawler } from './CnnTranscriptListCrawler'


### PR DESCRIPTION
This creates the crawler and parallel queue for the CNN transcript list pages.  These pages are basically just a list of links to actual transcripts.

This breaks out the helper functions for CNN transcripts and url parsing into its own utils/cnn.js

Related to issue #24 