### PR TITLE
Remove consoles

### DIFF
--- a/src/scripts/listScheduledJobs.js
+++ b/src/scripts/listScheduledJobs.js
@@ -1,12 +1,14 @@
 import queueDicts from '../server/queues'
 import { getRepeatableJobsFromQueueDict } from '../server/utils/queue'
+import logger from '../server/utils/logger'
 
-const renderResults = (results) => {
-  results.forEach(result => console.log(result))
-}
+const renderJobList = jobList => jobList.forEach((job) => {
+  const { key } = job
+  logger.info(`Scheduled Job: ${key}`)
+})
 
 const promises = queueDicts.map(getRepeatableJobsFromQueueDict)
-Promise.all(promises).then((results) => {
-  renderResults(results)
+Promise.all(promises).then((jobLists) => {
+  jobLists.forEach(renderJobList)
   process.exit()
 })

--- a/src/scripts/scheduleJobs.js
+++ b/src/scripts/scheduleJobs.js
@@ -1,9 +1,10 @@
 import queueDicts from '../server/queues'
+import logger from '../server/utils/logger'
 
 const scheduleJobs = queueDict => queueDict.scheduler.scheduleJobs()
 
 const renderResults = (results) => {
-  results.forEach(result => console.log(`Scheduled job: ${result.name}`))
+  results.forEach(result => logger.info(`Scheduled job: ${result.name}`))
 }
 
 const promises = queueDicts.map(scheduleJobs)

--- a/src/scripts/unscheduleJobs.js
+++ b/src/scripts/unscheduleJobs.js
@@ -1,12 +1,12 @@
 import queueDicts from '../server/queues'
 import { getQueueFromQueueDict } from '../server/utils/queue'
+import logger from '../server/utils/logger'
 
 const softUnscheduleJobs = queueDict => queueDict.scheduler.unscheduleJobs()
 
 const hardUnscheduleJobs = async (queueDict) => {
   const queue = getQueueFromQueueDict(queueDict)
   const jobs = await queue.getRepeatableJobs()
-
   return Promise.all(jobs.map(job => queue.removeRepeatableByKey(job.key)))
 }
 
@@ -18,12 +18,9 @@ const unscheduleJobs = (queueDict) => {
   }
   return softUnscheduleJobs(queueDict)
 }
-const renderResults = (results) => {
-  console.log(results)
-}
 
 const promises = queueDicts.map(unscheduleJobs)
 Promise.all(promises).then((results) => {
-  renderResults(results)
+  logger.info(`Jobs ${isHardFlagSet() ? '(hard) ' : ''}unscheduled for ${results.length} queues`)
   process.exit()
 })

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,14 +1,15 @@
 import queueDicts from './queues'
 import { getQueueFromQueueDict } from './utils/queue'
+import logger from './utils/logger'
 
 queueDicts.forEach(async (queueDict) => {
   const queue = getQueueFromQueueDict(queueDict)
   const repeatableJobs = await queue.getRepeatableJobs()
 
-  console.log(`==${queue.name} Jobs==`)
+  logger.info(`==${queue.name} Jobs==`)
   if (repeatableJobs.length === 0) {
-    console.log('none')
+    logger.info('no scheduled jobs')
   } else {
-    repeatableJobs.forEach(job => console.log(`* ${job.name} (${job.cron})`))
+    repeatableJobs.forEach(job => logger.info(`* ${job.name} (${job.cron})`))
   }
 })

--- a/src/server/workers/crawlers/AbstractCrawler.js
+++ b/src/server/workers/crawlers/AbstractCrawler.js
@@ -1,5 +1,7 @@
 import rp from 'request-promise'
 
+import logger from '../../utils/logger'
+
 class AbstractCrawler {
   constructor(crawlUrl) {
     this.crawlUrl = crawlUrl
@@ -29,7 +31,7 @@ class AbstractCrawler {
     return rp(this.crawlUrl)
       .then(this.crawlHandler)
       .catch((err) => {
-        console.log(err)
+        logger.error(err)
       })
   }
 }


### PR DESCRIPTION
This resolves #34 by actually using the logger to replace existing instances of console.log throughout the code base.  We may want to some day have a pass on existing queues to add more logging information.