### PR TITLE
Implement CNN Transcript Scraper

### DIFF
--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -2,43 +2,796 @@ import {
   isTranscriptListUrl,
   isTranscriptUrl,
   getFullCnnUrl,
+  removeTimestamps,
+  removeSpeakerReminders,
+  removeDescriptors,
+  addBreaksOnSpeakerChange,
+  splitTranscriptIntoChunks,
+  getAttributionFromChunk,
+  getStatementFromChunk,
+  getNameFromAttribution,
+  getAffiliationFromAttribution,
+  extractStatementFromChunk,
+  extractStatementsFromChunks,
+  getSpeakersFromStatements,
+  cleanSpeakerName,
+  cleanStatementSpeakerNames,
+  hasIdenticalName,
+  improvesName,
+  improvesAffiliation,
+  getBestAffiliation,
+  getBestName,
+  getNormalizedSpeaker,
+  normalizeStatementSpeakers,
+  removeNetworkAffiliatedStatements,
+  removeUnattributableStatements,
 } from '../cnn'
 
-describe('isTranscriptListUrl', () => {
-  it('Should not improperly identify transcript list urls', () => {
-    expect(isTranscriptListUrl('http://google.com'))
-      .toBe(false)
-  })
-  it('Should identify transcript list urls', () => {
-    expect(isTranscriptListUrl('/TRANSCRIPTS/2019.06.01.html'))
-      .toBe(true)
-  })
-})
 
-describe('isTranscriptUrl', () => {
-  it('Should not improperly identify transcript urls', () => {
-    expect(isTranscriptUrl('http://google.com'))
-      .toBe(false)
+describe('utils/cnn', () => {
+  describe('isTranscriptListUrl', () => {
+    it('Should not improperly identify transcript list urls', () => {
+      expect(isTranscriptListUrl('http://google.com'))
+        .toBe(false)
+    })
+    it('Should identify transcript list urls', () => {
+      expect(isTranscriptListUrl('/TRANSCRIPTS/2019.06.01.html'))
+        .toBe(true)
+    })
   })
-  it('Should identify transcript list urls', () => {
-    expect(isTranscriptUrl('/TRANSCRIPTS/1906/01/cnr.20.html'))
-      .toBe(true)
-  })
-})
 
-describe('getFullCnnUrl', () => {
-  it('Should not modify a complete url', () => {
-    expect(getFullCnnUrl('http://google.com'))
-      .toBe('http://google.com')
-    expect(getFullCnnUrl('http://cnn.com'))
-      .toBe('http://cnn.com')
+  describe('isTranscriptUrl', () => {
+    it('Should not improperly identify transcript urls', () => {
+      expect(isTranscriptUrl('http://google.com'))
+        .toBe(false)
+    })
+    it('Should identify transcript list urls', () => {
+      expect(isTranscriptUrl('/TRANSCRIPTS/1906/01/cnr.20.html'))
+        .toBe(true)
+    })
   })
-  it('Should prepend a relative url', () => {
-    expect(getFullCnnUrl('TRANSCRIPTS'))
-      .toBe('http://cnn.com/TRANSCRIPTS')
+
+  describe('getFullCnnUrl', () => {
+    it('Should not modify a complete url', () => {
+      expect(getFullCnnUrl('http://google.com'))
+        .toBe('http://google.com')
+      expect(getFullCnnUrl('http://cnn.com'))
+        .toBe('http://cnn.com')
+    })
+    it('Should prepend a relative url', () => {
+      expect(getFullCnnUrl('TRANSCRIPTS'))
+        .toBe('http://cnn.com/TRANSCRIPTS')
+    })
+    it('Should prepend a relative url starting with /', () => {
+      expect(getFullCnnUrl('/TRANSCRIPTS'))
+        .toBe('http://cnn.com/TRANSCRIPTS')
+    })
   })
-  it('Should prepend a relative url starting with /', () => {
-    expect(getFullCnnUrl('/TRANSCRIPTS'))
-      .toBe('http://cnn.com/TRANSCRIPTS')
+
+  describe('removeTimestamps', () => {
+    it('Should remove timestamps of format [dd:dd:dd]', () => {
+      expect(removeTimestamps('[00:00:00] This is a test.'))
+        .toBe('This is a test.')
+      expect(removeTimestamps('This [00:00:00] is a test.'))
+        .toBe('This is a test.')
+      expect(removeTimestamps('Again, [00:00:00] this is a test.'))
+        .toBe('Again, this is a test.')
+      expect(removeTimestamps('This is a test [00:00:00].'))
+        .toBe('This is a test.')
+      expect(removeTimestamps('This is a test.[00:00:00]'))
+        .toBe('This is a test.')
+    })
+    it('Should not remove references to time', () => {
+      expect(removeTimestamps('I jumped around at 10:00:00 PM'))
+        .toBe('I jumped around at 10:00:00 PM')
+    })
+  })
+
+  describe('removeSpeakerReminders', () => {
+    it('Should remove speaker reminder inserts', () => {
+      expect(removeSpeakerReminders('I just -- JOAN DOE: -- love potatoes so much'))
+        .toBe('I just love potatoes so much')
+      expect(removeSpeakerReminders('-- JIMMY BLIMMY -- All reports indicate that I am literally on fire'))
+        .toBe('All reports indicate that I am literally on fire')
+      expect(removeSpeakerReminders('Nobody can eat that many eggs. -- KING JOHN --'))
+        .toBe('Nobody can eat that many eggs.')
+    })
+    it('Should not remove other interjections', () => {
+      expect(removeSpeakerReminders('I fear that they -- the clown army -- are going to destroy us all.'))
+        .toBe('I fear that they -- the clown army -- are going to destroy us all.')
+    })
+  })
+
+  describe('removeDescriptors', () => {
+    it('Should remove generic descriptors', () => {
+      expect(removeDescriptors('(TALKING WITH MOUTH FULL) these pickles are delicious'))
+        .toBe('these pickles are delicious')
+      expect(removeDescriptors('Here, (THROWS ARTIFICIAL LIMB) take my hand!'))
+        .toBe('Here, take my hand!')
+      expect(removeDescriptors('Follow me! (JUMPS INTO BRICK WALL)'))
+        .toBe('Follow me!')
+    })
+    it('Should remove voice over indicators', () => {
+      expect(removeDescriptors('(voice-over) behold the largest swarm of bees in the world'))
+        .toBe('behold the largest swarm of bees in the world')
+      expect(removeDescriptors('(voice- over) they turn humans into honey.'))
+        .toBe('they turn humans into honey.')
+    })
+    it('Should remove telephone indicators', () => {
+      expect(removeDescriptors('(via telephone) Hello? who is this? Why do you keep calling me?'))
+        .toBe('Hello? who is this? Why do you keep calling me?')
+      expect(removeDescriptors('Buzz buzz (via telephone)'))
+        .toBe('Buzz buzz')
+    })
+
+    it('Should not remove normal parantheticals', () => {
+      expect(removeDescriptors('I am sure it will all be fine (aside from all the problems of course.)'))
+        .toBe('I am sure it will all be fine (aside from all the problems of course.)')
+    })
+  })
+
+  describe('addBreaksOnSpeakerChange', () => {
+    it('Should create line breaks on speaker change', () => {
+      expect(addBreaksOnSpeakerChange('DONNA: My name is Donna.  JOHNNA: My name is... Johnna?  Who wrote this.'))
+        .toBe('DONNA: My name is Donna.\nJOHNNA: My name is... Johnna?  Who wrote this.')
+    })
+    it('Should not create line breaks for one speaker', () => {
+      expect(removeTimestamps('DONNA: Whoever it is they seem to be running out of ideas.'))
+        .toBe('DONNA: Whoever it is they seem to be running out of ideas.')
+    })
+    it('Should not create line breaks for all-caps words', () => {
+      expect(removeTimestamps('PROGRAMMER: LOOK. WHAT DO YOU EXPECT.'))
+        .toBe('PROGRAMMER: LOOK. WHAT DO YOU EXPECT.')
+    })
+  })
+
+  describe('splitTranscriptIntoChunks', () => {
+    it('Should split a transcript into chunks', () => {
+      expect(splitTranscriptIntoChunks('DONNA: My name is Donna.\nJOHNNA: My name is... Johnna?  Who wrote this.'))
+        .toEqual([
+          'DONNA: My name is Donna.',
+          'JOHNNA: My name is... Johnna?  Who wrote this.',
+        ])
+    })
+  })
+
+  describe('getAttributionFromChunk', () => {
+    it('Should extract the attribution from a chunk', () => {
+      expect(getAttributionFromChunk('DONNA: My name is Donna.'))
+        .toEqual('DONNA')
+      expect(getAttributionFromChunk('DONNA, SLAYER OF CAKES: My name is Donna.'))
+        .toEqual('DONNA, SLAYER OF CAKES')
+    })
+  })
+
+  describe('getStatementFromChunk', () => {
+    it('Should extract the statement from a chunk', () => {
+      expect(getStatementFromChunk('DONNA: My name is Donna.'))
+        .toEqual('My name is Donna.')
+      expect(getStatementFromChunk('DONNA, SLAYER OF CAKES: My name is Donna.'))
+        .toEqual('My name is Donna.')
+    })
+  })
+
+  describe('getNameFromAttribution', () => {
+    it('Should extract the name from an attribution', () => {
+      expect(getNameFromAttribution('DONNA'))
+        .toEqual('DONNA')
+      expect(getNameFromAttribution('DONNA LITTLE'))
+        .toEqual('DONNA LITTLE')
+      expect(getNameFromAttribution('DONNA, SLAYER OF CAKES'))
+        .toEqual('DONNA')
+      expect(getNameFromAttribution('DONNA LITTLE, SLAYER OF CAKES'))
+        .toEqual('DONNA LITTLE')
+    })
+  })
+
+  describe('getAffiliationFromAttribution', () => {
+    it('Should extract the affiliation from an attribution', () => {
+      expect(getAffiliationFromAttribution('DONNA'))
+        .toEqual('')
+      expect(getAffiliationFromAttribution('DONNA LITTLE'))
+        .toEqual('')
+      expect(getAffiliationFromAttribution('DONNA, SLAYER OF CAKES'))
+        .toEqual('SLAYER OF CAKES')
+      expect(getAffiliationFromAttribution('DONNA LITTLE, SLAYER OF CAKES'))
+        .toEqual('SLAYER OF CAKES')
+    })
+  })
+
+  describe('extractStatementFromChunk', () => {
+    it('Should convert a chunk into a statement', () => {
+      expect(extractStatementFromChunk('DONNA: My name is Donna.'))
+        .toEqual({
+          speaker: {
+            name: 'DONNA',
+            affiliation: '',
+          },
+          statement: 'My name is Donna.',
+        })
+      expect(extractStatementFromChunk('DONNA, CNN ANCHOR: My name is Donna.'))
+        .toEqual({
+          speaker: {
+            name: 'DONNA',
+            affiliation: 'CNN ANCHOR',
+          },
+          statement: 'My name is Donna.',
+        })
+    })
+  })
+
+  describe('extractStatementsFromChunks', () => {
+    it('Should convert chunks into statements', () => {
+      expect(extractStatementsFromChunks([
+        'DONNA, MASTER OF HIDE AND SEEK: My name is Donna.',
+        'JOHNNA, FRIEND OF SQUIRRELS: My name is... Johnna?  Who wrote this.',
+      ]))
+        .toEqual([{
+          speaker: {
+            name: 'DONNA',
+            affiliation: 'MASTER OF HIDE AND SEEK',
+          },
+          statement: 'My name is Donna.',
+        }, {
+          speaker: {
+            name: 'JOHNNA',
+            affiliation: 'FRIEND OF SQUIRRELS',
+          },
+          statement: 'My name is... Johnna?  Who wrote this.',
+        }])
+    })
+  })
+
+  describe('getSpeakersFromStatements', () => {
+    it('Should return a list of unique speakers', () => {
+      expect(getSpeakersFromStatements([{
+        speaker: {
+          name: 'DONNA',
+          affiliation: '',
+        },
+        statement: 'My name is Donna.',
+      }, {
+        speaker: {
+          name: 'JOHNNA',
+          affiliation: '',
+        },
+        statement: 'My name is... Johnna?  Who wrote this.',
+      }, {
+        speaker: {
+          name: 'DONNA',
+          affiliation: '',
+        },
+        statement: 'I did.',
+      }, {
+        speaker: {
+          name: 'JOHNNA',
+          affiliation: 'CLONE OF JOHNNA',
+        },
+        statement: 'My name is... also Johnna?',
+      }]))
+        .toEqual([{
+          name: 'DONNA',
+          affiliation: '',
+        }, {
+          name: 'JOHNNA',
+          affiliation: '',
+        }, {
+          name: 'JOHNNA',
+          affiliation: 'CLONE OF JOHNNA',
+        }])
+    })
+  })
+
+  describe('cleanSpeakerName', () => {
+    it('Should remove honorifics', () => {
+      expect(cleanSpeakerName('SENATOR JIMMY DUST'))
+        .toBe('JIMMY DUST')
+      expect(cleanSpeakerName('SEN. JIMMY DUST'))
+        .toBe('JIMMY DUST')
+      expect(cleanSpeakerName('REPRESENTATIVE JIMMY DUST'))
+        .toBe('JIMMY DUST')
+    })
+  })
+
+  describe('cleanStatementSpeakerNames', () => {
+    it('Should remove honorifics', () => {
+      expect(cleanStatementSpeakerNames([{
+        speaker: {
+          name: 'REPRESENTATIVE DONNA BUTTERS',
+          affiliation: '',
+        },
+        statement: 'My name is Donna.',
+      }, {
+        speaker: {
+          name: 'SEN. JOHNNA',
+          affiliation: '',
+        },
+        statement: 'My name is... Johnna?  Who wrote this.',
+      }, {
+        speaker: {
+          name: 'SENATOR JOHNNA',
+          affiliation: '',
+        },
+        statement: 'Turns out I am a senator',
+      }]))
+        .toEqual([{
+          speaker: {
+            name: 'DONNA BUTTERS',
+            affiliation: '',
+          },
+          statement: 'My name is Donna.',
+        }, {
+          speaker: {
+            name: 'JOHNNA',
+            affiliation: '',
+          },
+          statement: 'My name is... Johnna?  Who wrote this.',
+        }, {
+          speaker: {
+            name: 'JOHNNA',
+            affiliation: '',
+          },
+          statement: 'Turns out I am a senator',
+        }])
+    })
+  })
+
+  describe('hasIdenticalName', () => {
+    it('Should properly identify speakers with identical names', () => {
+      expect(hasIdenticalName({
+        name: 'DONNA',
+        affiliation: '',
+      }, {
+        name: 'DONNA',
+        affiliation: 'BLORP',
+      }))
+        .toBe(true)
+    })
+    it('Should properly identify non-identical names', () => {
+      expect(hasIdenticalName({
+        name: 'DONNA',
+        affiliation: '',
+      }, {
+        name: 'DONNA THE SECOND',
+        affiliation: '',
+      }))
+        .toBe(false)
+    })
+  })
+
+  describe('improvesName', () => {
+    it('Should properly identify speakers with improved names', () => {
+      expect(improvesName({
+        name: 'DON DONNA',
+        affiliation: '',
+      }, {
+        name: 'DONNA',
+        affiliation: 'BLORP',
+      }))
+        .toBe(true)
+      expect(improvesName({
+        name: 'DON DON DONNA',
+        affiliation: '',
+      }, {
+        name: 'DONNA',
+        affiliation: 'BLORP',
+      }))
+        .toBe(true)
+    })
+    it('Should properly not identify speakers with not improved names', () => {
+      expect(improvesName({
+        name: 'DONNA',
+        affiliation: '',
+      }, {
+        name: 'DONNA',
+        affiliation: '',
+      }))
+        .toBe(false)
+      expect(improvesName({
+        name: 'DONNA',
+        affiliation: '',
+      }, {
+        name: 'DONNA DONNA',
+        affiliation: '',
+      }))
+        .toBe(false)
+      expect(improvesName({
+        name: 'JANE THE MASTER',
+        affiliation: '',
+      }, {
+        name: 'DONNA',
+        affiliation: '',
+      }))
+        .toBe(false)
+    })
+  })
+
+  describe('improvesAffiliation', () => {
+    it('Should properly identify improved affiliations', () => {
+      expect(improvesAffiliation({
+        name: 'DONNA',
+        affiliation: 'JEANS WEARER',
+      }, {
+        name: 'DONNA',
+        affiliation: '',
+      }))
+        .toBe(true)
+      expect(improvesAffiliation({
+        name: 'DONNA',
+        affiliation: 'JEANS WEARER',
+      }, {
+        name: 'KIMBERLY',
+        affiliation: '',
+      }))
+        .toBe(true)
+    })
+    it('Should properly not identify non-improved affiliations', () => {
+      expect(improvesAffiliation({
+        name: 'DONNA',
+        affiliation: '',
+      }, {
+        name: 'DONNA THE SECOND',
+        affiliation: 'MOST AMAZING PERSON',
+      }))
+        .toBe(false)
+      expect(improvesAffiliation({
+        name: 'DONNA',
+        affiliation: '',
+      }, {
+        name: 'DONNA THE SECOND',
+        affiliation: '',
+      }))
+        .toBe(false)
+      expect(improvesAffiliation({
+        name: 'DONNA',
+        affiliation: '',
+      }, {
+        name: 'DONNA THE SECOND',
+        affiliation: '',
+      }))
+        .toBe(false)
+    })
+    it('Should not identify improvement if an affiliation exists', () => {
+      expect(improvesAffiliation({
+        name: 'DONNA',
+        affiliation: 'A COOL PERSON',
+      }, {
+        name: 'DONNA',
+        affiliation: 'MOST AMAZING PERSON',
+      }))
+        .toBe(false)
+    })
+  })
+
+  describe('getBestAffiliation', () => {
+    it('Should return the original affiliation when names do not improve or equal', () => {
+      expect(getBestAffiliation({
+        name: 'DONNA',
+        affiliation: '',
+      }, {
+        name: 'DONNA JANE',
+        affiliation: 'JEANS WEARER',
+      }))
+        .toBe('JEANS WEARER')
+      expect(getBestAffiliation({
+        name: 'DONNA',
+        affiliation: 'PANTRY',
+      }, {
+        name: 'DONNA JANE',
+        affiliation: 'JEANS WEARER',
+      }))
+        .toBe('JEANS WEARER')
+    })
+    it('Should return the best affiliation when names improve or equal', () => {
+      expect(getBestAffiliation({
+        name: 'DONNA',
+        affiliation: 'JEANS WEARER',
+      }, {
+        name: 'DONNA',
+        affiliation: '',
+      }))
+        .toBe('JEANS WEARER')
+      expect(getBestAffiliation({
+        name: 'DONNA',
+        affiliation: '',
+      }, {
+        name: 'DONNA',
+        affiliation: 'JEANS WEARER',
+      }))
+        .toBe('JEANS WEARER')
+      expect(getBestAffiliation({
+        name: 'DONNA',
+        affiliation: '',
+      }, {
+        name: 'JOHN DONNA',
+        affiliation: 'MOST AMAZING PERSON',
+      }))
+        .toBe('MOST AMAZING PERSON')
+    })
+    it('Should not override existing affiliation', () => {
+      expect(getBestAffiliation({
+        name: 'DONNA',
+        affiliation: 'A COOL PERSON',
+      }, {
+        name: 'DONNA',
+        affiliation: 'MOST AMAZING PERSON',
+      }))
+        .toBe('MOST AMAZING PERSON')
+      expect(getBestAffiliation({
+        name: 'DONNA',
+        affiliation: 'A COOL PERSON',
+      }, {
+        name: 'DONNA DONNA',
+        affiliation: 'MOST AMAZING PERSON',
+      }))
+        .toBe('MOST AMAZING PERSON')
+      expect(getBestAffiliation({
+        name: 'DONNA',
+        affiliation: 'A COOL PERSON',
+      }, {
+        name: 'JOHN JOHNNA',
+        affiliation: 'MOST AMAZING PERSON',
+      }))
+        .toBe('MOST AMAZING PERSON')
+    })
+  })
+
+  describe('getBestName', () => {
+    it('Should return the original name when last names are not shared', () => {
+      expect(getBestName({
+        name: 'DONNA JANE',
+        affiliation: '',
+      }, {
+        name: 'DONNA',
+        affiliation: 'JEANS WEARER',
+      }))
+        .toBe('DONNA')
+      expect(getBestName({
+        name: 'DON DONDON',
+        affiliation: 'PANTRY',
+      }, {
+        name: 'DON DON',
+        affiliation: 'JEANS WEARER',
+      }))
+        .toBe('DON DON')
+    })
+    it('Should return the longer name when the endings match', () => {
+      expect(getBestName({
+        name: 'DONNA DONNA',
+        affiliation: 'JEANS WEARER',
+      }, {
+        name: 'DONNA',
+        affiliation: '',
+      }))
+        .toBe('DONNA DONNA')
+      expect(getBestName({
+        name: 'DON DON DONNA',
+        affiliation: '',
+      }, {
+        name: 'DONNA',
+        affiliation: 'JEANS WEARER',
+      }))
+        .toBe('DON DON DONNA')
+    })
+    it('Should not return shorter names', () => {
+      expect(getBestName({
+        name: 'DONNA',
+        affiliation: 'A COOL PERSON',
+      }, {
+        name: 'DONNA DONNA',
+        affiliation: 'MOST AMAZING PERSON',
+      }))
+        .toBe('DONNA DONNA')
+    })
+  })
+
+  describe('getNormalizedSpeaker', () => {
+    it('Should use the first full name', () => {
+      expect(getNormalizedSpeaker({
+        name: 'JOHN',
+        affiliation: '',
+      }, [{
+        name: 'JOHNNY JOHN',
+        affiliation: 'PORTLAND',
+      }, {
+        name: 'JOHN',
+        affiliation: 'PHILADEPHIA',
+      }, {
+        name: 'JOHN JOHN',
+        affiliation: 'BORTLAND',
+      }]))
+        .toEqual({
+          name: 'JOHNNY JOHN',
+          affiliation: 'PORTLAND',
+        })
+    })
+    it('Should use the most complete name', () => {
+      expect(getNormalizedSpeaker({
+        name: 'JOHN',
+        affiliation: '',
+      }, [{
+        name: 'JOHNNY JOHN',
+        affiliation: 'PORTLAND',
+      }, {
+        name: 'JOHN',
+        affiliation: 'PHILADEPHIA',
+      }, {
+        name: 'BOB JOHNNY JOHN',
+        affiliation: 'BORTLAND',
+      }]))
+        .toEqual({
+          name: 'BOB JOHNNY JOHN',
+          affiliation: 'BORTLAND',
+        })
+    })
+    it('Should use the most complete affiliation', () => {
+      expect(getNormalizedSpeaker({
+        name: 'JOHN',
+        affiliation: '',
+      }, [{
+        name: 'JOHN',
+        affiliation: '',
+      }, {
+        name: 'JOHN',
+        affiliation: 'PHILADEPHIA',
+      }]))
+        .toEqual({
+          name: 'JOHN',
+          affiliation: 'PHILADEPHIA',
+        })
+    })
+    it('Should not drop affiliation', () => {
+      expect(getNormalizedSpeaker({
+        name: 'JOHN',
+        affiliation: 'PHILADELPHIA',
+      }, [{
+        name: 'JOHN',
+        affiliation: '',
+      }, {
+        name: 'JOHN',
+        affiliation: 'WISCONSON',
+      }]))
+        .toEqual({
+          name: 'JOHN',
+          affiliation: 'PHILADELPHIA',
+        })
+      expect(getNormalizedSpeaker({
+        name: 'JOHN',
+        affiliation: 'PHILADELPHIA',
+      }, [{
+        name: 'JOHN',
+        affiliation: '',
+      }, {
+        name: 'JOHN JOHN',
+        affiliation: 'WISCONSON',
+      }]))
+        .toEqual({
+          name: 'JOHN JOHN',
+          affiliation: 'PHILADELPHIA',
+        })
+    })
+  })
+
+  describe('normalizeStatementSpeakers', () => {
+    it('Should replace names with long names', () => {
+      expect(normalizeStatementSpeakers([{
+        speaker: {
+          name: 'DONNA BUTTERS',
+          affiliation: 'CNN HOST',
+        },
+        statement: 'My name is Donna.',
+      }, {
+        speaker: {
+          name: 'LANCE',
+          affiliation: '',
+        },
+        statement: 'My name is... Johnna?  Who wrote this.',
+      }, {
+        speaker: {
+          name: 'BUTTERS',
+          affiliation: '',
+        },
+        statement: 'lol idk.',
+      }, {
+        speaker: {
+          name: 'JOHNNA LANCE',
+          affiliation: 'CNN TOAST',
+        },
+        statement: 'does this even matter?',
+      }]))
+        .toEqual([{
+          speaker: {
+            name: 'DONNA BUTTERS',
+            affiliation: 'CNN HOST',
+          },
+          statement: 'My name is Donna.',
+        }, {
+          speaker: {
+            name: 'JOHNNA LANCE',
+            affiliation: 'CNN TOAST',
+          },
+          statement: 'My name is... Johnna?  Who wrote this.',
+        }, {
+          speaker: {
+            name: 'DONNA BUTTERS',
+            affiliation: 'CNN HOST',
+          },
+          statement: 'lol idk.',
+        }, {
+          speaker: {
+            name: 'JOHNNA LANCE',
+            affiliation: 'CNN TOAST',
+          },
+          statement: 'does this even matter?',
+        }])
+    })
+  })
+
+  describe('removeNetworkAffiliatedStatements', () => {
+    it('Should remove CNN affiliates', () => {
+      expect(removeNetworkAffiliatedStatements([{
+        speaker: {
+          name: 'DONNA BUTTERS',
+          affiliation: 'CNN TALKING HEAD',
+        },
+        statement: 'My name is Donna.',
+      }, {
+        speaker: {
+          name: 'JOHNNA',
+          affiliation: 'CNN PANTS HIDER',
+        },
+        statement: 'My name is... Johnna?  Who wrote this.',
+      }, {
+        speaker: {
+          name: 'DONNA',
+          affiliation: 'OTHER PERSON',
+        },
+        statement: 'lol idk.',
+      }]))
+        .toEqual([{
+          speaker: {
+            name: 'DONNA',
+            affiliation: 'OTHER PERSON',
+          },
+          statement: 'lol idk.',
+        }])
+    })
+  })
+
+  describe('removeUnattributableStatements', () => {
+    it('Should remove unidentified speaker statements', () => {
+      expect(removeUnattributableStatements([{
+        speaker: {
+          name: 'UNIDENTIFIED MALE',
+          affiliation: '',
+        },
+        statement: 'Nobody knows who I am',
+      }, {
+        speaker: {
+          name: 'UNIDENTIFIED FEMALE',
+          affiliation: '',
+        },
+        statement: 'Same here.',
+      }, {
+        speaker: {
+          name: 'UNIDENTIFIED ANIMAL',
+          affiliation: 'FARM',
+        },
+        statement: 'Moo.',
+      }, {
+        speaker: {
+          name: 'ANIMAL EXPERT',
+          affiliation: '',
+        },
+        statement: 'Wait I think that last one was a cow.',
+      }]))
+        .toEqual([{
+          speaker: {
+            name: 'ANIMAL EXPERT',
+            affiliation: '',
+          },
+          statement: 'Wait I think that last one was a cow.',
+        }])
+    })
   })
 })

--- a/src/server/utils/cnn.js
+++ b/src/server/utils/cnn.js
@@ -1,3 +1,14 @@
+/**
+ * @typedef {Object} Speaker
+ * @property {String} name
+ * @property {String} affiliation
+ */
+
+/**
+ * @typedef {Object} Statement
+ * @property {Speaker} speaker The person who made the statement.
+ * @property {String}  statement What the person actually said
+ */
 
 export const isTranscriptListUrl = url => url.startsWith('/TRANSCRIPTS/')
   && url.endsWith('.html')
@@ -10,3 +21,281 @@ export const getFullCnnUrl = (url) => {
   if (url.startsWith('/')) return `http://cnn.com${url}`
   return `http://cnn.com/${url}`
 }
+
+/**
+ * CNN Transcripts have occasional timestamps inserted.
+ * This will remove those timestamps.
+ *
+ * @param  {String} transcript The transcript we want to modify.
+ * @return {String}            The modified transcript with timestamps removed.
+ */
+export const removeTimestamps = transcript => transcript
+  .replace(/\s?\[\d\d:\d\d:\d\d\]/g, '')
+  .trim()
+
+/**
+ * CNN transcripts have randomly inserted reminders of who is talking.
+ * This will remove those reminders.
+ *
+ * @param  {String} transcript The transcript we want to modify.
+ * @return {String}            The modified transcript with reminders removed.
+ */
+export const removeSpeakerReminders = transcript => transcript
+  .replace(/\s*--\s*[A-Z\s]*:?\s*--/g, '')
+  .trim()
+
+/**
+ * CNN transcripts sometimes have descriptors to indicate context
+ * This will remove those descriptors.
+ *
+ * @param  {String} transcript The transcript we want to modify.
+ * @return {String}            The modified transcript with descriptors removed.
+ */
+export const removeDescriptors = transcript => transcript
+  .replace(/\s?\([A-Z\s]*\)/g, '')
+  .replace(/\s?\(voice[\s-]*over\)/, '')
+  .replace(/\s?\(via telephone\)/, '')
+  .trim()
+
+/**
+ * Insert new lines in a transcript when the speaker has changed.
+ *
+ * @param  {String} transcript The transcript we want to modify.
+ * @return {String}            The modified transcript with line breaks inserted.
+ */
+export const addBreaksOnSpeakerChange = transcript => transcript
+  .replace(/([.?!\-)\]])\s*([.,A-Z\s]*:)/g, '$1\n$2')
+
+
+/**
+ * Converts a transcript into a bunch of smaller pieces which can later be
+ * processed into statements.
+ *
+ * @param  {String} transcript The transcript we want to parse.
+ * @return {String[]}          The chunks of the transcript.
+ */
+export const splitTranscriptIntoChunks = transcript => transcript.split('\n')
+
+// Used to identify the speaker section of a chunk
+const chunkSpeakerRegex = /[.,A-Z\s]+[:]/
+
+/**
+ * Extract the speaker name / affiliation from a chunk.
+ *
+ * @param  {String} chunk The segment of a transcript which contains a speaker and a statement.
+ * @return {String}       The portion of the chunk that describes the person who was speaking.
+ */
+export const getAttributionFromChunk = chunk => chunk
+  .match(chunkSpeakerRegex)[0]
+  .slice(0, -1).trim()
+
+/**
+ * Extract the content of what was said from a chunk.
+ *
+ * @param  {String} chunk The segment of a transcript which contains a speaker and a statement.
+ * @return {String}       The portion of the chunk that contains what was said.
+ */
+export const getStatementFromChunk = chunk => chunk
+  .replace(chunkSpeakerRegex, '').trim()
+
+/**
+ * Extract the person's name from an attribution string.
+ *
+ * @param  {String} attribution The full string describing a person.
+ * @return {String}             The portion of the attribution that contains the person's name
+ */
+export const getNameFromAttribution = attribution => attribution
+  .match(/[A-Z\s]+/)[0]
+
+/**
+ * Extract the person's affiliation from an attribution string.
+ *
+ * @param  {String} attribution The full string describing a person.
+ * @return {String}             The portion of the attribution that contains
+ *                                  the person's affiliation
+ */
+export const getAffiliationFromAttribution = attribution => (
+  (attribution.match(/,([A-Z\s,]*)/)
+  || [','])[0]
+    .substring(1)
+    .trim()
+)
+
+/**
+ * Extracts a statement object from a portion of a transcript.
+ *
+ * @param  {[type]} chunk The portion of a transcript containing a single statement
+ * @return {Statement}    The statement object extracted from the chunk.
+ */
+export const extractStatementFromChunk = (chunk) => {
+  const attribution = getAttributionFromChunk(chunk)
+  const statement = getStatementFromChunk(chunk)
+  const name = getNameFromAttribution(attribution)
+  const affiliation = getAffiliationFromAttribution(attribution)
+
+  return {
+    speaker: {
+      name,
+      affiliation,
+    },
+    statement,
+  }
+}
+
+/**
+ * Converts a list of chunks into a list of statement objects.
+ *
+ * @param  {String[]} chunks The list of transcript chunks
+ * @return {Statement[]}     The list of extracted statement objects
+ */
+export const extractStatementsFromChunks = chunks => chunks.map(
+  extractStatementFromChunk,
+)
+
+/**
+ * Returns a list of unique speakers from a list of statements
+ *
+ * @param  {Statement[]} statements The list of statement objects we want to process
+ * @return {Speaker[]}              The list of unique speaker objects
+ */
+export const getSpeakersFromStatements = (statements) => {
+  const speakers = statements.map(statement => statement.speaker)
+  return speakers.reduce((unique, a) => {
+    const isUnique = !unique.find(
+      b => (a.name === b.name
+        && a.affiliation === b.affiliation),
+    )
+    if (isUnique) {
+      unique.push(a)
+    }
+    return unique
+  }, [])
+}
+
+/**
+ * Removes everything that isn't an actual name from a speaker name.
+ *
+ * @param  {String} name The name that needs to be cleaned.
+ * @return {String}      The cleaned version of the name.
+ */
+export const cleanSpeakerName = name => name
+  .replace('SENATOR ', '')
+  .replace('REPRESENTATIVE ', '')
+  .replace('SEN. ', '')
+
+/**
+ * Cleans all speaker names in a list of statements
+ *
+ * @param  {Statement[]} statements The list of statements to process
+ * @return {Statement[]}            The cleaned list of statements
+ */
+export const cleanStatementSpeakerNames = statements => statements.map(
+  (statement) => {
+    const newStatement = Object.assign({}, statement)
+    newStatement.speaker.name = cleanSpeakerName(statement.speaker.name)
+    return newStatement
+  },
+)
+
+export const hasIdenticalName = (a, b) => a.name === b.name
+
+/**
+ * This method compares a candidate name with a starting name.
+ * If the names are different, and if the candidate name explicitly
+ * expands the speaker's name then it is considered an improvement.
+ *
+ * NOTE: this ONLY considering a names that explicitly add given names
+ * for example JAMESON => JAMES JAMESON is considered an improvement, but
+ * JAMES => JAMES JAMESON is not.
+ *
+ * @param  {String} a The speaker name we want to improve
+ * @param  {String} b The candidate name for improvement
+ * @return {bool}     True if the candidate name is an improvement
+ */
+export const improvesName = (a, b) => !hasIdenticalName(a, b)
+  && a.name.endsWith(` ${b.name}`)
+
+
+/**
+ * This method compares a candidate affiliation with a starting affiliation.
+ * If the starting affiliation is not empty it cannot be improved.  Likewise
+ * if a candidate affiliation is empty it is not an improvement.
+ *
+ * @param  {String} a The speaker affiliation we want to improve
+ * @param  {String} b The candidate affiliation for improvement
+ * @return {bool}     True if the candidate affiliation is an improvement
+ */
+export const improvesAffiliation = (a, b) => a.affiliation.length !== 0
+  && b.affiliation.length === 0
+
+/**
+ * This method compares a candidate speaker with the existing speaker
+ * and, if both speakers seem to be referring to the same person it will
+ * return which affiliation to use.
+ *
+ * @param  {Speaker} a The speaker we want to improve
+ * @param  {Speaker} b The candidate for improvement
+ * @return {String}    The best affiliation
+ */
+export const getBestAffiliation = (a, b) => (
+  (improvesAffiliation(a, b)
+  && (hasIdenticalName(a, b)
+  || improvesName(a, b))) ? a.affiliation : b.affiliation
+)
+
+/**
+ * This method compares a candidate speaker with the existing speaker
+ * and, if both speakers seem to be referring to the same person it will
+ * return which name to use.
+ *
+ * @param  {Speaker} a The speaker we want to improve
+ * @param  {Speaker} b The candidate for improvement
+ * @return {String}    The best name
+ */
+export const getBestName = (a, b) => (
+  improvesName(a, b) ? a.name : b.name
+)
+
+/**
+ * Normalize a speaker attributions with the most canonical version of that
+ * attribution included in a list of all speakers seen so far.
+ *
+ * @param  {Speaker} speaker       The speaker that needs to be normalized.
+ * @param  {Speaker[]} allSpeakers The full list of possible speaker values.
+ * @return {Speaker}               The selected speaker.
+ */
+export const getNormalizedSpeaker = (speaker, allSpeakers) => allSpeakers
+  .reduce((best, next) => {
+    const newBest = Object.assign({}, best)
+    if (improvesName(next, best)) {
+      newBest.name = getBestName(next, speaker)
+    }
+    if (improvesName(next, best)
+    || hasIdenticalName(next, best)) {
+      newBest.affiliation = getBestAffiliation(next, speaker)
+    }
+    return newBest
+  }, speaker)
+
+/**
+ * Normalizes all speakers in a set of statements so that the same
+ * speaker maintains the same name and attribution even if the original
+ * original transcript modified the names over time.
+ *
+ * @param  {Statement[]} statements The list of statements to normalize
+ * @return {Statement[]}           The list of normalized statements
+ */
+export const normalizeStatementSpeakers = (statements) => {
+  const speakers = getSpeakersFromStatements(statements)
+  return statements.map(statement => Object.assign({}, statement, {
+    speaker: getNormalizedSpeaker(statement.speaker, speakers),
+  }))
+}
+
+export const removeNetworkAffiliatedStatements = statements => statements.filter(
+  statement => !statement.speaker.affiliation.includes('CNN'),
+)
+
+export const removeUnattributableStatements = statements => statements.filter(
+  statement => !statement.speaker.name.includes('UNIDENTIFIED'),
+)

--- a/src/server/workers/scrapers/AbstractStatementScraper.js
+++ b/src/server/workers/scrapers/AbstractStatementScraper.js
@@ -1,0 +1,40 @@
+import rp from 'request-promise'
+
+import logger from '../../utils/logger'
+
+class AbstractStatementScraper {
+  constructor(scrapeUrl) {
+    this.scrapeUrl = scrapeUrl
+  }
+
+  /**
+   * Process the result of an HTTP request and identify the urls
+   * to pass into the scraper pipeline.
+   *
+   * Each scraper that extends AbstractStatementScraper needs to implement its own
+   * scrapeHandler method.
+   *
+   * @param {String} htmlString The HTML or JSON that came from the HTTP request
+   * @return {Object[]}         the list of statements that were scraped
+   */
+  // (this is an abstract method and we need to define its footprint.)
+  // eslint-disable-next-line no-unused-vars
+  scrapeHandler = (responseString) => {
+    throw new Error('You implemented a statement scraper but forgot to define the scrapeHandler.')
+  }
+
+  /**
+   * Runs the crawler
+   *
+   * @return {Promise} a Promise to provide a list of URLs that came fromthe crawl handler
+   */
+  async run() {
+    return rp(this.scrapeUrl)
+      .then(this.scrapeHandler)
+      .catch((err) => {
+        logger.error(err)
+      })
+  }
+}
+
+export default AbstractStatementScraper

--- a/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
+++ b/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
@@ -1,0 +1,56 @@
+import cheerio from 'cheerio'
+
+import {
+  removeTimestamps,
+  removeSpeakerReminders,
+  removeDescriptors,
+  addBreaksOnSpeakerChange,
+  splitTranscriptIntoChunks,
+  extractStatementsFromChunks,
+  removeNetworkAffiliatedStatements,
+  removeUnattributableStatements,
+  cleanStatementSpeakerNames,
+  normalizeStatementSpeakers,
+} from '../../utils/cnn'
+
+import AbstractStatementScraper from './AbstractStatementScraper'
+
+const $ = cheerio
+
+class CnnTranscriptStatementScraper extends AbstractStatementScraper {
+  getTranscriptText = (html) => {
+    const $bodyTextElements = $(html).find('.cnnBodyText')
+    const bodyTexts = $bodyTextElements.map((i, element) => $(element).text())
+
+    if (bodyTexts.length < 3) {
+      throw new Error('The CnnTranscriptStatementScraper received an unexpected transcript format.')
+    }
+    return bodyTexts[2]
+  }
+
+  extractStatementsFromTranscript = (transcript) => {
+    const stepSequence = [
+      removeTimestamps,
+      removeSpeakerReminders,
+      removeDescriptors,
+      addBreaksOnSpeakerChange,
+      splitTranscriptIntoChunks,
+      extractStatementsFromChunks,
+      removeNetworkAffiliatedStatements,
+      removeUnattributableStatements,
+      cleanStatementSpeakerNames,
+      normalizeStatementSpeakers,
+    ] // Note that order does matter here
+
+    const statements = stepSequence.reduce((string, fn) => fn(string), transcript)
+    return statements
+  }
+
+  scrapeHandler = (responseString) => {
+    const transcript = this.getTranscriptText(responseString)
+    const statements = this.extractStatementsFromTranscript(transcript)
+    return statements
+  }
+}
+
+export default CnnTranscriptStatementScraper


### PR DESCRIPTION
Scrapers are slightly different from crawlers, though we may find reason to abstract common elements between the two since they both work with HTTP requests.

This implements our first scraper, the CNNTranscriptStatementScraper which takes a transcript URL and spits out statements (text attributed to a speaker).

These statements eventually need to be processed and passed to ClaimBuster, which will refine the statements into claims.

This does NOT create a queue for it.

Issue #24