### PR TITLE
Add cnn transcript scraper queue

### DIFF
--- a/src/server/queues/cnnTranscriptListCrawlerQueue/cnnTranscriptListCrawlerJobProcessor.js
+++ b/src/server/queues/cnnTranscriptListCrawlerQueue/cnnTranscriptListCrawlerJobProcessor.js
@@ -1,5 +1,11 @@
 import { CnnTranscriptListCrawler } from '../../workers/crawlers/CnnCrawlers'
 
+import cnnTranscriptStatementScraperQueueDict from '../cnnTranscriptStatementScraperQueue'
+
+const statementScraperQueue = cnnTranscriptStatementScraperQueueDict.factory.getQueue()
+
+const scrapeTranscriptUrl = url => statementScraperQueue.add({ url })
+
 export default async (job) => {
   const {
     data: {
@@ -8,5 +14,6 @@ export default async (job) => {
   } = job
   const crawler = new CnnTranscriptListCrawler(url)
   const crawlResults = await crawler.run()
+  crawlResults.forEach(scrapeTranscriptUrl)
   return crawlResults
 }

--- a/src/server/queues/cnnTranscriptStatementScraperQueue/CnnTranscriptStatementScraperJobScheduler.js
+++ b/src/server/queues/cnnTranscriptStatementScraperQueue/CnnTranscriptStatementScraperJobScheduler.js
@@ -1,0 +1,13 @@
+import CnnTranscriptStatementScraperQueueFactory from './CnnTranscriptStatementScraperQueueFactory'
+import AbstractJobScheduler from '../AbstractJobScheduler'
+import { Schedules } from '../constants'
+
+const getQueueFactory = () => new CnnTranscriptStatementScraperQueueFactory()
+
+class CnnTranscriptStatementScraperJobScheduler extends AbstractJobScheduler {
+  getScheduleCron = () => Schedules.None
+
+  getQueue = () => getQueueFactory().getQueue()
+}
+
+export default CnnTranscriptStatementScraperJobScheduler

--- a/src/server/queues/cnnTranscriptStatementScraperQueue/CnnTranscriptStatementScraperQueueFactory.js
+++ b/src/server/queues/cnnTranscriptStatementScraperQueue/CnnTranscriptStatementScraperQueueFactory.js
@@ -1,0 +1,10 @@
+import { QueueNames } from '../constants'
+import AbstractQueueFactory from '../AbstractQueueFactory'
+
+class CnnTranscriptStatementScraperQueueFactory extends AbstractQueueFactory {
+  getQueueName = () => QueueNames.scraperQueues.CNN_TRANSCRIPT_STATEMENT
+
+  getPathToProcessor = () => `${__dirname}/cnnTranscriptStatementScraperJobProcessor.js`
+}
+
+export default CnnTranscriptStatementScraperQueueFactory

--- a/src/server/queues/cnnTranscriptStatementScraperQueue/cnnTranscriptStatementScraperJobProcessor.js
+++ b/src/server/queues/cnnTranscriptStatementScraperQueue/cnnTranscriptStatementScraperJobProcessor.js
@@ -1,0 +1,12 @@
+import CnnTranscriptStatementScraper from '../../workers/scrapers/CnnTranscriptStatementScraper'
+
+export default async (job) => {
+  const {
+    data: {
+      url,
+    },
+  } = job
+  const scraper = new CnnTranscriptStatementScraper(url)
+  const statements = await scraper.run()
+  return statements
+}

--- a/src/server/queues/cnnTranscriptStatementScraperQueue/index.js
+++ b/src/server/queues/cnnTranscriptStatementScraperQueue/index.js
@@ -1,0 +1,9 @@
+import CnnTranscriptStatementScraperQueueFactory from './CnnTranscriptStatementScraperQueueFactory'
+import CnnTranscriptStatementScraperJobScheduler from './CnnTranscriptStatementScraperJobScheduler'
+import cnnTranscriptStatementScraperJobProcessor from './cnnTranscriptStatementScraperJobProcessor'
+
+export default {
+  factory: new CnnTranscriptStatementScraperQueueFactory(),
+  scheduler: new CnnTranscriptStatementScraperJobScheduler(),
+  processor: cnnTranscriptStatementScraperJobProcessor,
+}

--- a/src/server/queues/constants.js
+++ b/src/server/queues/constants.js
@@ -12,4 +12,7 @@ export const QueueNames = {
     CNN_TRANSCRIPT_LIST: 'cnnTranscriptListCrawler',
     HELLO_WORLD: 'helloWorldCrawler',
   },
+  scraperQueues: {
+    CNN_TRANSCRIPT_STATEMENT: 'cnnTranscriptStatementScraper',
+  },
 }

--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -134,6 +134,8 @@ describe('utils/cnn', () => {
     it('Should create line breaks on speaker change', () => {
       expect(addBreaksOnSpeakerChange('DONNA: My name is Donna.  JOHNNA: My name is... Johnna?  Who wrote this.'))
         .toBe('DONNA: My name is Donna.\nJOHNNA: My name is... Johnna?  Who wrote this.')
+      expect(addBreaksOnSpeakerChange('JANE: testing. ELIANA JOHNSON, NATIONAL POLITICAL REPORTER, "POLITICO": Testing'))
+        .toBe('JANE: testing.\nELIANA JOHNSON, NATIONAL POLITICAL REPORTER, "POLITICO": Testing')
     })
     it('Should not create line breaks for one speaker', () => {
       expect(removeTimestamps('DONNA: Whoever it is they seem to be running out of ideas.'))
@@ -161,6 +163,12 @@ describe('utils/cnn', () => {
         .toEqual('DONNA')
       expect(getAttributionFromChunk('DONNA, SLAYER OF CAKES: My name is Donna.'))
         .toEqual('DONNA, SLAYER OF CAKES')
+      expect(getAttributionFromChunk('REV. AL SHARPTON (D), PRESIDENTIAL CANDIDATE: Schwarzenegger is an impostor. You will see at the end of this that I\'m the real Terminator. I want to terminate Bush.'))
+        .toEqual('REV. AL SHARPTON (D), PRESIDENTIAL CANDIDATE')
+    })
+    it('Should return an empty attribution if none exists', () => {
+      expect(getAttributionFromChunk('This has no attribution'))
+        .toEqual('')
     })
   })
 
@@ -184,18 +192,32 @@ describe('utils/cnn', () => {
       expect(getNameFromAttribution('DONNA LITTLE, SLAYER OF CAKES'))
         .toEqual('DONNA LITTLE')
     })
+    it('Should return an empty name if there is no attribution', () => {
+      expect(getNameFromAttribution(''))
+        .toEqual('')
+    })
   })
 
   describe('getAffiliationFromAttribution', () => {
-    it('Should extract the affiliation from an attribution', () => {
-      expect(getAffiliationFromAttribution('DONNA'))
-        .toEqual('')
-      expect(getAffiliationFromAttribution('DONNA LITTLE'))
-        .toEqual('')
+    it('Should extract the affiliation from an attribution if one exists', () => {
       expect(getAffiliationFromAttribution('DONNA, SLAYER OF CAKES'))
         .toEqual('SLAYER OF CAKES')
       expect(getAffiliationFromAttribution('DONNA LITTLE, SLAYER OF CAKES'))
         .toEqual('SLAYER OF CAKES')
+      expect(getAffiliationFromAttribution('DONNA LITTLE, SLAYER OF "CAKES"'))
+        .toEqual('SLAYER OF "CAKES"')
+      expect(getAffiliationFromAttribution('DONNA LITTLE, SLAYER OF "CAKES" (RETIRED)'))
+        .toEqual('SLAYER OF "CAKES" (RETIRED)')
+    })
+    it('Should return an empty affiliation if there is no affiliation', () => {
+      expect(getAffiliationFromAttribution('DONNA'))
+        .toEqual('')
+      expect(getAffiliationFromAttribution('DONNA LITTLE'))
+        .toEqual('')
+    })
+    it('Should return an empty affiliation if there is no attribution', () => {
+      expect(getAffiliationFromAttribution(''))
+        .toEqual('')
     })
   })
 

--- a/src/server/utils/cnn.js
+++ b/src/server/utils/cnn.js
@@ -64,7 +64,7 @@ export const removeDescriptors = transcript => transcript
  * @return {String}            The modified transcript with line breaks inserted.
  */
 export const addBreaksOnSpeakerChange = transcript => transcript
-  .replace(/([.?!\-)\]])\s*([.,A-Z\s]*:)/g, '$1\n$2')
+  .replace(/([.?!\-)\]])\s*([.,A-Z\s"()]*:)/g, '$1\n$2')
 
 
 /**
@@ -77,7 +77,7 @@ export const addBreaksOnSpeakerChange = transcript => transcript
 export const splitTranscriptIntoChunks = transcript => transcript.split('\n')
 
 // Used to identify the speaker section of a chunk
-const chunkSpeakerRegex = /[.,A-Z\s]+[:]/
+const chunkAttributionRegex = /[.,A-Z\s"()]+[:]/
 
 /**
  * Extract the speaker name / affiliation from a chunk.
@@ -85,9 +85,11 @@ const chunkSpeakerRegex = /[.,A-Z\s]+[:]/
  * @param  {String} chunk The segment of a transcript which contains a speaker and a statement.
  * @return {String}       The portion of the chunk that describes the person who was speaking.
  */
-export const getAttributionFromChunk = chunk => chunk
-  .match(chunkSpeakerRegex)[0]
-  .slice(0, -1).trim()
+export const getAttributionFromChunk = chunk => (
+  (chunk.match(chunkAttributionRegex)
+  || [':'])[0]
+    .slice(0, -1).trim()
+)
 
 /**
  * Extract the content of what was said from a chunk.
@@ -96,7 +98,7 @@ export const getAttributionFromChunk = chunk => chunk
  * @return {String}       The portion of the chunk that contains what was said.
  */
 export const getStatementFromChunk = chunk => chunk
-  .replace(chunkSpeakerRegex, '').trim()
+  .replace(chunkAttributionRegex, '').trim()
 
 /**
  * Extract the person's name from an attribution string.
@@ -104,9 +106,10 @@ export const getStatementFromChunk = chunk => chunk
  * @param  {String} attribution The full string describing a person.
  * @return {String}             The portion of the attribution that contains the person's name
  */
-export const getNameFromAttribution = attribution => attribution
-  .match(/[A-Z\s]+/)[0]
-
+export const getNameFromAttribution = attribution => (
+  (attribution.match(/[A-Z\s.()]+/)
+  || [''])[0]
+)
 /**
  * Extract the person's affiliation from an attribution string.
  *
@@ -115,7 +118,7 @@ export const getNameFromAttribution = attribution => attribution
  *                                  the person's affiliation
  */
 export const getAffiliationFromAttribution = attribution => (
-  (attribution.match(/,([A-Z\s,]*)/)
+  (attribution.match(/,([A-Z\s,"()]*)/)
   || [','])[0]
     .substring(1)
     .trim()

--- a/src/server/utils/logger.js
+++ b/src/server/utils/logger.js
@@ -39,7 +39,7 @@ if (config.NODE_ENV !== 'production') {
       format.colorize(),
       format.timestamp(),
       format.align(),
-      format.printf(info => `${info.timestamp} (${info.level}): ${info.message}`),
+      format.printf(info => `${info.timestamp} (${info.level}): ${info.message} ${info.stack}`),
     ),
   }))
 }

--- a/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
+++ b/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
@@ -1,6 +1,8 @@
 import cheerio from 'cheerio'
 
 import {
+  isTranscriptUrl,
+  getFullCnnUrl,
   removeTimestamps,
   removeSpeakerReminders,
   removeDescriptors,
@@ -18,6 +20,13 @@ import AbstractStatementScraper from './AbstractStatementScraper'
 const $ = cheerio
 
 class CnnTranscriptStatementScraper extends AbstractStatementScraper {
+  constructor(url) {
+    if (!isTranscriptUrl(url)) {
+      throw new Error('CnnTranscriptStatementScraper was passed a URL that does not appear to be a CNN transcript.')
+    }
+    super(getFullCnnUrl(url))
+  }
+
   getTranscriptText = (html) => {
     const $bodyTextElements = $(html).find('.cnnBodyText')
     const bodyTexts = $bodyTextElements.map((i, element) => $(element).text())


### PR DESCRIPTION
This creates a queue for the CNN transcript statement scraper.  It also includes a few little fixes to the scraper that came up in the first 30 seconds of testing.

Oh, it also has a little tweak to our logger so that errors render the stack trace; that should have always been there.

Related to Issue #24 