### PR TITLE
Create a common scrape class

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,7 @@ MAILER_FROM_ADDRESS='Visible Name <email@address.com>'
 MAILGUN_API_DOMAIN=domain.org
 MAILGUN_API_URL=https://api.mailgun.net/v3/domain.org
 MAILGUN_API_KEY=ABC123
+
+# The amount of detail you want to appear in logs
+# We use the default npm log levels as described in https://github.com/winstonjs/winston#logging-levels
+LOG_LEVEL=info

--- a/src/server/utils/logger.js
+++ b/src/server/utils/logger.js
@@ -7,7 +7,7 @@ import {
 import config from '../config'
 
 const logger = createLogger({
-  level: 'info',
+  level: config.LOG_LEVEL || 'info',
   format: format.combine(
     format.timestamp({
       format: 'YYYY-MM-DD HH:mm:ss',
@@ -39,7 +39,7 @@ if (config.NODE_ENV !== 'production') {
       format.colorize(),
       format.timestamp(),
       format.align(),
-      format.printf(info => `${info.timestamp} (${info.level}): ${info.message} ${info.stack}`),
+      format.printf(info => `${info.timestamp} (${info.level}): ${info.message} ${info.stack || ''}`),
     ),
   }))
 }

--- a/src/server/workers/crawlers/AbstractCrawler.js
+++ b/src/server/workers/crawlers/AbstractCrawler.js
@@ -1,12 +1,6 @@
-import rp from 'request-promise'
+import AbstractScraper from '../scrapers/AbstractScraper'
 
-import logger from '../../utils/logger'
-
-class AbstractCrawler {
-  constructor(crawlUrl) {
-    this.crawlUrl = crawlUrl
-  }
-
+class AbstractCrawler extends AbstractScraper {
   /**
    * Process the result of an HTTP request and identify the urls
    * to pass into the scraper pipeline.
@@ -23,17 +17,7 @@ class AbstractCrawler {
     throw new Error('You wrote a new crawler but forgot to define the crawlHandler.')
   }
 
-  /**
-   * Runs the crawler
-   * @return Promise a promise that returns the list of URLs that came fromthe crawl handler
-   */
-  async run() {
-    return rp(this.crawlUrl)
-      .then(this.crawlHandler)
-      .catch((err) => {
-        logger.error(err)
-      })
-  }
+  scrapeHandler = responseString => this.crawlHandler(responseString)
 }
 
 export default AbstractCrawler

--- a/src/server/workers/crawlers/__test__/HelloWorldCrawler.test.js
+++ b/src/server/workers/crawlers/__test__/HelloWorldCrawler.test.js
@@ -3,10 +3,6 @@ import HelloWorldCrawler from '../HelloWorldCrawler'
 const crawler = new HelloWorldCrawler()
 
 describe('HelloWorldCrawler', () => {
-  it('Should have a crawl URL', () => {
-    expect(crawler).toHaveProperty('crawlUrl')
-    expect(crawler.crawlUrl).toMatch(/^http/)
-  })
   it('Should have a crawl handler function', () => {
     expect(crawler).toHaveProperty('crawlHandler')
     expect(crawler.crawlHandler).toBeInstanceOf(Function)

--- a/src/server/workers/scrapers/AbstractScraper.js
+++ b/src/server/workers/scrapers/AbstractScraper.js
@@ -1,0 +1,46 @@
+import rp from 'request-promise'
+
+import logger from '../../utils/logger'
+
+class AbstractScraper {
+  constructor(scrapeUrl) {
+    this.scrapeUrl = scrapeUrl
+    logger.info(`Initialized ${this.constructor.name} (${this.scrapeUrl})`)
+  }
+
+  /**
+   * Process the result of an HTTP request.  The result of the scrape will
+   * depend on the nature of the extending class.
+   *
+   * Each scraper that extends AbstractScraper needs to implement its own
+   * scrapeHandler method.
+   *
+   * @param {String} htmlString The HTML or JSON that came from the HTTP request
+   * @return {Object}           Whatever object the scraper is intended to output
+   */
+  // (this is an abstract method and we need to define its footprint.)
+  // eslint-disable-next-line no-unused-vars
+  scrapeHandler = (responseString) => {
+    throw new Error('You implemented a scraper but forgot to define the scrapeHandler.')
+  }
+
+  /**
+   * Runs the scraper
+   *
+   * @return {Promise} A Promise to provide the results of the scrape
+   */
+  async run() {
+    logger.debug(`Getting (${this.scrapeUrl})`)
+    return rp(this.scrapeUrl)
+      .then((responseString) => {
+        logger.debug(`Processing (${this.scrapeUrl})`)
+        this.scrapeHandler(responseString)
+      })
+      .catch((err) => {
+        logger.debug(`Errored (${this.scrapeUrl})`)
+        logger.error(err)
+      })
+  }
+}
+
+export default AbstractScraper

--- a/src/server/workers/scrapers/AbstractStatementScraper.js
+++ b/src/server/workers/scrapers/AbstractStatementScraper.js
@@ -1,40 +1,23 @@
-import rp from 'request-promise'
+import AbstractScraper from './AbstractScraper'
 
-import logger from '../../utils/logger'
-
-class AbstractStatementScraper {
-  constructor(scrapeUrl) {
-    this.scrapeUrl = scrapeUrl
-  }
-
+class AbstractStatementScraper extends AbstractScraper {
   /**
-   * Process the result of an HTTP request and identify the urls
-   * to pass into the scraper pipeline.
+   * Statement scrapers are designed to extract statements from the
+   * scraped page.
    *
-   * Each scraper that extends AbstractStatementScraper needs to implement its own
-   * scrapeHandler method.
+   * Each statement scraper that extends AbstractStatementScraper needs to implement
+   * its own statementScrapeHandler method.
    *
-   * @param {String} htmlString The HTML or JSON that came from the HTTP request
-   * @return {Object[]}         the list of statements that were scraped
+   * @param {String} responseString The HTML or JSON that came from the HTTP request
+   * @return {Object[]}             The list of statements that were scraped
    */
   // (this is an abstract method and we need to define its footprint.)
   // eslint-disable-next-line no-unused-vars
-  scrapeHandler = (responseString) => {
-    throw new Error('You implemented a statement scraper but forgot to define the scrapeHandler.')
+  statementScrapeHandler = (responseString) => {
+    throw new Error('You implemented a statement scraper but forgot to define the statementScrapeHandler.')
   }
 
-  /**
-   * Runs the crawler
-   *
-   * @return {Promise} a Promise to provide a list of URLs that came fromthe crawl handler
-   */
-  async run() {
-    return rp(this.scrapeUrl)
-      .then(this.scrapeHandler)
-      .catch((err) => {
-        logger.error(err)
-      })
-  }
+  scrapeHandler = responseString => this.statementScrapeHandler(responseString)
 }
 
 export default AbstractStatementScraper

--- a/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
+++ b/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
@@ -55,7 +55,7 @@ class CnnTranscriptStatementScraper extends AbstractStatementScraper {
     return statements
   }
 
-  scrapeHandler = (responseString) => {
+  statementScrapeHandler = (responseString) => {
     const transcript = this.getTranscriptText(responseString)
     const statements = this.extractStatementsFromTranscript(transcript)
     return statements


### PR DESCRIPTION
Statement scrapes and crawls are both different types of scraper.  As described in #60, there is value in having both types of scraper extend a common class so we can avoid redundant supporting logic.

This PR implements that common class.  It also sneaks in a little bit of augmentation to our logger (and a bug fix where stack trace would render as undefined when a log line didn't include an error)

This resolves #60 