### PR TITLE
Don’t do verbose coverage testing on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,4 @@ node_js:
 
 script:
   - npm run lint
-  - npm run test
-  
+  - npm run test:ci

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "./node_modules/.bin/eslint 'src/**/*.js'",
     "test": "jest --verbose --coverage",
     "test:watch": "jest --verbose --watch",
+    "test:ci": "jest",
     "migrate": "sequelize db:migrate",
     "queue:jobs:list": "babel-node -- src/scripts/listScheduledJobs",
     "queue:jobs:schedule": "babel-node -- src/scripts/scheduleJobs",


### PR DESCRIPTION
CI doesn’t benefit from coverage testing or verbose results, so configure Travis to use a special version without those options.

Closes #69