### PR TITLE
Integrate ClaimBuster

### DIFF
--- a/src/server/constants.js
+++ b/src/server/constants.js
@@ -1,6 +1,3 @@
-/* eslint-disable import/prefer-default-export */
-/* This will eventually have more than one item, so we do not want a default export */
-
 export const ENV_NAMES = {
   DEVELOPMENT: 'development',
   TEST: 'test',

--- a/src/server/constants.js
+++ b/src/server/constants.js
@@ -6,3 +6,5 @@ export const ENV_NAMES = {
   TEST: 'test',
   PRODUCTION: 'production',
 }
+
+export const CLAIMBUSTER_THRESHHOLD = 0.5

--- a/src/server/migrations/20190703142652-add-affiliation.js
+++ b/src/server/migrations/20190703142652-add-affiliation.js
@@ -1,0 +1,14 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface
+    .addColumn(
+      'speakers',
+      'affiliation',
+      Sequelize.STRING,
+    ),
+
+  down: queryInterface => queryInterface
+    .reoveColumn(
+      'speakers',
+      'affiliation',
+    ),
+}

--- a/src/server/models/speaker.js
+++ b/src/server/models/speaker.js
@@ -1,6 +1,7 @@
 module.exports = (sequelize, DataTypes) => {
   const Speaker = sequelize.define('Speaker', {
     fullName: DataTypes.STRING,
+    affiliation: DataTypes.STRING,
   }, {})
   Speaker.associate = (models) => {
     Speaker.hasMany(models.Claim, {

--- a/src/server/queues/AbstractJobScheduler.js
+++ b/src/server/queues/AbstractJobScheduler.js
@@ -1,11 +1,6 @@
 
 class AbstractJobScheduler {
   /**
-   * The cron string representing the schedule to be run
-   *
-   * OVERRIDE WHEN EXTENDING
-   */
-  /**
    * Abstract method that provides the cron string representing the schedule to be run.
    * The schedule should ultimately be stored as a constant in queues/index.js
    *

--- a/src/server/queues/claimBusterClaimDetectorQueue/ClaimBusterClaimDetectorJobScheduler.js
+++ b/src/server/queues/claimBusterClaimDetectorQueue/ClaimBusterClaimDetectorJobScheduler.js
@@ -1,0 +1,13 @@
+import ClaimBusterClaimDetectorQueueFactory from './ClaimBusterClaimDetectorQueueFactory'
+import AbstractJobScheduler from '../AbstractJobScheduler'
+import { Schedules } from '../constants'
+
+const getQueueFactory = () => new ClaimBusterClaimDetectorQueueFactory()
+
+class ClaimBusterClaimDetectorJobScheduler extends AbstractJobScheduler {
+  getScheduleCron = () => Schedules.None
+
+  getQueue = () => getQueueFactory().getQueue()
+}
+
+export default ClaimBusterClaimDetectorJobScheduler

--- a/src/server/queues/claimBusterClaimDetectorQueue/ClaimBusterClaimDetectorQueueFactory.js
+++ b/src/server/queues/claimBusterClaimDetectorQueue/ClaimBusterClaimDetectorQueueFactory.js
@@ -1,0 +1,10 @@
+import { QueueNames } from '../constants'
+import AbstractQueueFactory from '../AbstractQueueFactory'
+
+class ClaimBusterClaimDetectorQueueFactory extends AbstractQueueFactory {
+  getQueueName = () => QueueNames.claimDetectorQueues.CLAIM_BUSTER
+
+  getPathToProcessor = () => `${__dirname}/claimBusterClaimDetectorJobProcessor.js`
+}
+
+export default ClaimBusterClaimDetectorQueueFactory

--- a/src/server/queues/claimBusterClaimDetectorQueue/claimBusterClaimDetectorJobProcessor.js
+++ b/src/server/queues/claimBusterClaimDetectorQueue/claimBusterClaimDetectorJobProcessor.js
@@ -1,0 +1,25 @@
+import logger from '../../utils/logger'
+import models from '../../models'
+import { ClaimBusterClaimDetector } from '../../workers/claimDetectors'
+
+const { Claim } = models
+
+const saveClaim = async claim => Claim.create({
+  content: claim.text,
+  claimBusterScore: claim.score,
+})
+
+export default async (job) => {
+  const {
+    data: {
+      statement,
+    },
+  } = job
+  logger.info(`Extracting claims from statement: ${statement.text}`)
+  const claimDetector = new ClaimBusterClaimDetector(statement)
+  const claims = await claimDetector.getClaims()
+  logger.info(`Total claims extracted: ${claims.length}`)
+
+  claims.forEach(saveClaim)
+  return claims
+}

--- a/src/server/queues/claimBusterClaimDetectorQueue/index.js
+++ b/src/server/queues/claimBusterClaimDetectorQueue/index.js
@@ -1,0 +1,9 @@
+import ClaimBusterClaimDetectorQueueFactory from './ClaimBusterClaimDetectorQueueFactory'
+import ClaimBusterClaimDetectorJobScheduler from './ClaimBusterClaimDetectorJobScheduler'
+import claimBusterClaimDetectorJobProcessor from './claimBusterClaimDetectorJobProcessor'
+
+export default {
+  factory: new ClaimBusterClaimDetectorQueueFactory(),
+  scheduler: new ClaimBusterClaimDetectorJobScheduler(),
+  processor: claimBusterClaimDetectorJobProcessor,
+}

--- a/src/server/queues/cnnTranscriptStatementScraperQueue/cnnTranscriptStatementScraperJobProcessor.js
+++ b/src/server/queues/cnnTranscriptStatementScraperQueue/cnnTranscriptStatementScraperJobProcessor.js
@@ -1,4 +1,9 @@
 import CnnTranscriptStatementScraper from '../../workers/scrapers/CnnTranscriptStatementScraper'
+import claimBusterClaimDetectorQueueDict from '../claimBusterClaimDetectorQueue'
+
+const claimBusterClaimDetectorQueue = claimBusterClaimDetectorQueueDict.factory.getQueue()
+
+const detectClaims = statement => claimBusterClaimDetectorQueue.add({ statement })
 
 export default async (job) => {
   const {
@@ -8,5 +13,6 @@ export default async (job) => {
   } = job
   const scraper = new CnnTranscriptStatementScraper(url)
   const statements = await scraper.run()
+  statements.forEach(detectClaims)
   return statements
 }

--- a/src/server/queues/constants.js
+++ b/src/server/queues/constants.js
@@ -15,4 +15,7 @@ export const QueueNames = {
   scraperQueues: {
     CNN_TRANSCRIPT_STATEMENT: 'cnnTranscriptStatementScraper',
   },
+  claimDetectorQueues: {
+    CLAIM_BUSTER: 'claimBusterClaimDetector',
+  },
 }

--- a/src/server/utils/__test__/claimBuster.test.js
+++ b/src/server/utils/__test__/claimBuster.test.js
@@ -1,0 +1,34 @@
+import {
+  filterWeakClaims,
+} from '../claimBuster'
+
+import { CLAIMBUSTER_THRESHHOLD } from '../../constants'
+
+describe('filterWeakClaims', () => {
+  const dummyClaimData = [
+    { score: 100 },
+    { score: 90 },
+    { score: 80 },
+    { score: 70 },
+    { score: 60 },
+    { score: 50 },
+    { score: 40 },
+    { score: 30 },
+    { score: 20 },
+    { score: 10 },
+    { score: 0 },
+    { score: -1 },
+  ]
+  it(`Should remove claims that fall below ${CLAIMBUSTER_THRESHHOLD}`, () => {
+    const results = filterWeakClaims(dummyClaimData)
+    results.forEach(result => expect(result.score).toBeGreaterThan(CLAIMBUSTER_THRESHHOLD))
+  })
+  it(`Should keep claims that fall above ${CLAIMBUSTER_THRESHHOLD}`, () => {
+    const results = filterWeakClaims(dummyClaimData)
+    dummyClaimData.forEach((input) => {
+      if (input.score > CLAIMBUSTER_THRESHHOLD) {
+        expect(results).toContainEqual(input)
+      }
+    })
+  })
+})

--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -229,7 +229,7 @@ describe('utils/cnn', () => {
             name: 'DONNA',
             affiliation: '',
           },
-          statement: 'My name is Donna.',
+          text: 'My name is Donna.',
         })
       expect(extractStatementFromChunk('DONNA, CNN ANCHOR: My name is Donna.'))
         .toEqual({
@@ -237,7 +237,7 @@ describe('utils/cnn', () => {
             name: 'DONNA',
             affiliation: 'CNN ANCHOR',
           },
-          statement: 'My name is Donna.',
+          text: 'My name is Donna.',
         })
     })
   })
@@ -253,13 +253,13 @@ describe('utils/cnn', () => {
             name: 'DONNA',
             affiliation: 'MASTER OF HIDE AND SEEK',
           },
-          statement: 'My name is Donna.',
+          text: 'My name is Donna.',
         }, {
           speaker: {
             name: 'JOHNNA',
             affiliation: 'FRIEND OF SQUIRRELS',
           },
-          statement: 'My name is... Johnna?  Who wrote this.',
+          text: 'My name is... Johnna?  Who wrote this.',
         }])
     })
   })
@@ -271,25 +271,25 @@ describe('utils/cnn', () => {
           name: 'DONNA',
           affiliation: '',
         },
-        statement: 'My name is Donna.',
+        text: 'My name is Donna.',
       }, {
         speaker: {
           name: 'JOHNNA',
           affiliation: '',
         },
-        statement: 'My name is... Johnna?  Who wrote this.',
+        text: 'My name is... Johnna?  Who wrote this.',
       }, {
         speaker: {
           name: 'DONNA',
           affiliation: '',
         },
-        statement: 'I did.',
+        text: 'I did.',
       }, {
         speaker: {
           name: 'JOHNNA',
           affiliation: 'CLONE OF JOHNNA',
         },
-        statement: 'My name is... also Johnna?',
+        text: 'My name is... also Johnna?',
       }]))
         .toEqual([{
           name: 'DONNA',
@@ -322,38 +322,38 @@ describe('utils/cnn', () => {
           name: 'REPRESENTATIVE DONNA BUTTERS',
           affiliation: '',
         },
-        statement: 'My name is Donna.',
+        text: 'My name is Donna.',
       }, {
         speaker: {
           name: 'SEN. JOHNNA',
           affiliation: '',
         },
-        statement: 'My name is... Johnna?  Who wrote this.',
+        text: 'My name is... Johnna?  Who wrote this.',
       }, {
         speaker: {
           name: 'SENATOR JOHNNA',
           affiliation: '',
         },
-        statement: 'Turns out I am a senator',
+        text: 'Turns out I am a senator',
       }]))
         .toEqual([{
           speaker: {
             name: 'DONNA BUTTERS',
             affiliation: '',
           },
-          statement: 'My name is Donna.',
+          text: 'My name is Donna.',
         }, {
           speaker: {
             name: 'JOHNNA',
             affiliation: '',
           },
-          statement: 'My name is... Johnna?  Who wrote this.',
+          text: 'My name is... Johnna?  Who wrote this.',
         }, {
           speaker: {
             name: 'JOHNNA',
             affiliation: '',
           },
-          statement: 'Turns out I am a senator',
+          text: 'Turns out I am a senator',
         }])
     })
   })
@@ -701,50 +701,50 @@ describe('utils/cnn', () => {
           name: 'DONNA BUTTERS',
           affiliation: 'CNN HOST',
         },
-        statement: 'My name is Donna.',
+        text: 'My name is Donna.',
       }, {
         speaker: {
           name: 'LANCE',
           affiliation: '',
         },
-        statement: 'My name is... Johnna?  Who wrote this.',
+        text: 'My name is... Johnna?  Who wrote this.',
       }, {
         speaker: {
           name: 'BUTTERS',
           affiliation: '',
         },
-        statement: 'lol idk.',
+        text: 'lol idk.',
       }, {
         speaker: {
           name: 'JOHNNA LANCE',
           affiliation: 'CNN TOAST',
         },
-        statement: 'does this even matter?',
+        text: 'does this even matter?',
       }]))
         .toEqual([{
           speaker: {
             name: 'DONNA BUTTERS',
             affiliation: 'CNN HOST',
           },
-          statement: 'My name is Donna.',
+          text: 'My name is Donna.',
         }, {
           speaker: {
             name: 'JOHNNA LANCE',
             affiliation: 'CNN TOAST',
           },
-          statement: 'My name is... Johnna?  Who wrote this.',
+          text: 'My name is... Johnna?  Who wrote this.',
         }, {
           speaker: {
             name: 'DONNA BUTTERS',
             affiliation: 'CNN HOST',
           },
-          statement: 'lol idk.',
+          text: 'lol idk.',
         }, {
           speaker: {
             name: 'JOHNNA LANCE',
             affiliation: 'CNN TOAST',
           },
-          statement: 'does this even matter?',
+          text: 'does this even matter?',
         }])
     })
   })
@@ -756,26 +756,26 @@ describe('utils/cnn', () => {
           name: 'DONNA BUTTERS',
           affiliation: 'CNN TALKING HEAD',
         },
-        statement: 'My name is Donna.',
+        text: 'My name is Donna.',
       }, {
         speaker: {
           name: 'JOHNNA',
           affiliation: 'CNN PANTS HIDER',
         },
-        statement: 'My name is... Johnna?  Who wrote this.',
+        text: 'My name is... Johnna?  Who wrote this.',
       }, {
         speaker: {
           name: 'DONNA',
           affiliation: 'OTHER PERSON',
         },
-        statement: 'lol idk.',
+        text: 'lol idk.',
       }]))
         .toEqual([{
           speaker: {
             name: 'DONNA',
             affiliation: 'OTHER PERSON',
           },
-          statement: 'lol idk.',
+          text: 'lol idk.',
         }])
     })
   })
@@ -787,32 +787,32 @@ describe('utils/cnn', () => {
           name: 'UNIDENTIFIED MALE',
           affiliation: '',
         },
-        statement: 'Nobody knows who I am',
+        text: 'Nobody knows who I am',
       }, {
         speaker: {
           name: 'UNIDENTIFIED FEMALE',
           affiliation: '',
         },
-        statement: 'Same here.',
+        text: 'Same here.',
       }, {
         speaker: {
           name: 'UNIDENTIFIED ANIMAL',
           affiliation: 'FARM',
         },
-        statement: 'Moo.',
+        text: 'Moo.',
       }, {
         speaker: {
           name: 'ANIMAL EXPERT',
           affiliation: '',
         },
-        statement: 'Wait I think that last one was a cow.',
+        text: 'Wait I think that last one was a cow.',
       }]))
         .toEqual([{
           speaker: {
             name: 'ANIMAL EXPERT',
             affiliation: '',
           },
-          statement: 'Wait I think that last one was a cow.',
+          text: 'Wait I think that last one was a cow.',
         }])
     })
   })

--- a/src/server/utils/claimBuster.js
+++ b/src/server/utils/claimBuster.js
@@ -1,0 +1,7 @@
+/* eslint-disable import/prefer-default-export */
+// We may export other things some day.
+
+import { CLAIMBUSTER_THRESHHOLD } from '../constants'
+
+export const filterWeakClaims = claimBusterResults => claimBusterResults
+  .filter(result => result.score > CLAIMBUSTER_THRESHHOLD)

--- a/src/server/utils/cnn.js
+++ b/src/server/utils/cnn.js
@@ -7,7 +7,7 @@
 /**
  * @typedef {Object} Statement
  * @property {Speaker} speaker The person who made the statement.
- * @property {String}  statement What the person actually said
+ * @property {String}  text    What the person actually said
  */
 
 export const isTranscriptListUrl = url => url.startsWith('/TRANSCRIPTS/')
@@ -141,7 +141,7 @@ export const extractStatementFromChunk = (chunk) => {
       name,
       affiliation,
     },
-    statement,
+    text: statement,
   }
 }
 

--- a/src/server/workers/claimDetectors/ClaimBusterClaimDetector.js
+++ b/src/server/workers/claimDetectors/ClaimBusterClaimDetector.js
@@ -1,0 +1,29 @@
+import rp from 'request-promise'
+import { filterWeakClaims } from '../../utils/claimBuster'
+
+class ClaimBusterClaimDetector {
+  constructor(statement) {
+    this.statement = statement
+  }
+
+  getClaims = async () => {
+    const {
+      speaker,
+      text: statementText,
+    } = this.statement
+    const uri = `https://idir.uta.edu/factchecker/score_text/${statementText}`
+    return rp
+      .get({
+        uri,
+        json: true,
+      })
+      .then(data => filterWeakClaims(data.results)
+        .map(result => ({
+          speaker,
+          text: result.text,
+          score: result.score,
+        })))
+  }
+}
+
+export default ClaimBusterClaimDetector

--- a/src/server/workers/claimDetectors/index.js
+++ b/src/server/workers/claimDetectors/index.js
@@ -1,0 +1,4 @@
+/* eslint-disable import/prefer-default-export */
+// We may some day have other kinds of claim detectors
+
+export { default as ClaimBusterClaimDetector } from './ClaimBusterClaimDetector'


### PR DESCRIPTION
This is the final major component of the full claim extraction pipeline.  This PR creates a worker and queue for interacting with ClaimBuster.  The queue is responsible for actually using the output (e.g. storing into a database), and the worker is just responsible for doing the interaction and returning the list of scored claims.

We may want to someday avoid codifying the name ClaimBuster in the models, but they're there at this point so I didn't want to tweak that in this PR.

There is more to be done around storing data correctly, but I'm going to create those needs as separate issues and declare that this PR resolves #21 