### PR TITLE
Remove note about verifying test email recipients

### DIFF
--- a/src/scripts/sendTestEmail.js
+++ b/src/scripts/sendTestEmail.js
@@ -13,7 +13,7 @@ const getRecipient = () => {
 
 const recipient = getRecipient()
 if (!recipient) {
-  logger.error('Pass in a valid and Mailgun-verified email address with the `-r` parameter.')
+  logger.error('Pass in a valid email address with the `-r` parameter.')
   process.exit()
 }
 


### PR DESCRIPTION
Since we confirmed the domain with Mailgun in #61, we can send test emails to any recipient.

This is the tiniest PR ever and even asking for a review is an insult, so I'm going to Break With Protocol and merge it in.