### PR TITLE
Add real designed HTML template

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "redis": "^2.8.0",
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
+    "sanitize-html": "^1.20.1",
     "sequelize": "^5.8.5",
     "winston": "^3.2.1"
   },

--- a/src/scripts/sendTestEmail.js
+++ b/src/scripts/sendTestEmail.js
@@ -22,8 +22,10 @@ const sendTestEmail = () => new Promise(() => {
   return mailer.send({
     recipient,
     subject: 'This is a test email.',
-    bodyText: 'This is the text body of the email.',
-    bodyHTML: 'This is the <abbr title="HyperText Markup Language">HTML</abbr> body of the email.',
+    body: {
+      text: 'This is the text body of the email.',
+      html: 'This is the <abbr title="HyperText Markup Language">HTML</abbr> body of the email.',
+    },
   })
 })
 sendTestEmail().catch((error) => {

--- a/src/scripts/sendTestEmail.js
+++ b/src/scripts/sendTestEmail.js
@@ -22,7 +22,8 @@ const sendTestEmail = () => new Promise(() => {
   return mailer.send({
     recipient,
     subject: 'This is a test email.',
-    body: 'This is the body of the email.',
+    bodyText: 'This is the text body of the email.',
+    bodyHTML: 'This is the <abbr title="HyperText Markup Language">HTML</abbr> body of the email.',
   })
 })
 sendTestEmail().catch((error) => {

--- a/src/server/newsletters/HelloWorldNewsletter.js
+++ b/src/server/newsletters/HelloWorldNewsletter.js
@@ -1,27 +1,16 @@
-import models from '../models'
 import AbstractNewsletter from './AbstractNewsletter'
 import { MAILING_LISTS } from './constants'
-
-const { Claim, Speaker } = models
 
 class HelloWorldNewsletter extends AbstractNewsletter {
   getMailingList = () => MAILING_LISTS.DEVELOPERS
 
   getPathToTemplate = () => `${__dirname}/templates/helloWorld.hbs`
 
-  getSubject = () => 'Hello World: The Newsletter'
+  getPathToTextTemplate = () => `${__dirname}/templates/helloWorldText.hbs`
 
-  getClaims = () => (Claim.findAll({
-    limit: 5,
-    include: [{
-      model: Speaker,
-      as: 'speaker',
-    }],
-  }).then(claims => claims))
+  getSubject = () => '[DEV] Tech & Check Hello World'
 
-  getBodyData = async () => ({
-    claims: await this.getClaims(),
-  })
+  getBodyData = async () => ({})
 }
 
 export default HelloWorldNewsletter

--- a/src/server/newsletters/HelloWorldNewsletter.js
+++ b/src/server/newsletters/HelloWorldNewsletter.js
@@ -2,7 +2,7 @@ import models from '../models'
 import AbstractNewsletter from './AbstractNewsletter'
 import { MAILING_LISTS } from './constants'
 
-const { Claim } = models
+const { Claim, Speaker } = models
 
 class HelloWorldNewsletter extends AbstractNewsletter {
   getMailingList = () => MAILING_LISTS.DEVELOPERS
@@ -13,6 +13,10 @@ class HelloWorldNewsletter extends AbstractNewsletter {
 
   getClaims = () => (Claim.findAll({
     limit: 5,
+    include: [{
+      model: Speaker,
+      as: 'speaker',
+    }],
   }).then(claims => claims))
 
   getBodyData = async () => ({

--- a/src/server/newsletters/templates/default.hbs
+++ b/src/server/newsletters/templates/default.hbs
@@ -1,1 +1,1 @@
-This is the default email template. You probably need to point the newsletter to someting else.
+This is the default email template. You probably need to point the newsletter to something else.

--- a/src/server/newsletters/templates/helloWorld.hbs
+++ b/src/server/newsletters/templates/helloWorld.hbs
@@ -1,7 +1,23 @@
-This is the Hello World newsletter that plucks the five latest claims and sends them to the dev list.
+{{> head }}
 
-{{#each claims}}
-{{ content }}
-{{/each}}
+<p>This is the Hello World newsletter that plucks the five latest claims and sends them to the dev list.</p>
 
-That's all!
+<div class="claim-section">
+  <h1 class="claim-section__header">🔎 Testing Claims 🔍</h1>
+  <ul class="claims">
+  {{#each claims}}
+    <li class="claim" data-affiliation="{{ speaker.affiliation }}">
+      <div class="claim__metadata">
+        <a href="{{ sourceUrl }}" class="claim__permalink">
+          <cite class="claim__speaker">{{ speaker.fullName }}</cite>
+          <span class="claim__platform">(<b>{{ speaker.affiliation }}</b>)</span></a>:
+      </div>
+      <blockquote class="claim__content">{{ content }}</blockquote>
+    </li>
+  {{/each}}
+  </ul>
+</div>
+
+<p>You've reached the end of the email. Pat yourself on the back.</p>
+
+{{> foot }}

--- a/src/server/newsletters/templates/helloWorld.hbs
+++ b/src/server/newsletters/templates/helloWorld.hbs
@@ -1,23 +1,9 @@
 {{> head }}
 
-<p>This is the Hello World newsletter that plucks the five latest claims and sends them to the dev list.</p>
+<h1>Hello.</h1>
 
-<div class="claim-section">
-  <h1 class="claim-section__header">🔎 Testing Claims 🔍</h1>
-  <ul class="claims">
-  {{#each claims}}
-    <li class="claim" data-affiliation="{{ speaker.affiliation }}">
-      <div class="claim__metadata">
-        <a href="{{ sourceUrl }}" class="claim__permalink">
-          <cite class="claim__speaker">{{ speaker.fullName }}</cite>
-          <span class="claim__platform">(<b>{{ speaker.affiliation }}</b>)</span></a>:
-      </div>
-      <blockquote class="claim__content">{{ content }}</blockquote>
-    </li>
-  {{/each}}
-  </ul>
-</div>
+<p>This is the Hello World newsletter. It has no real content, performs no database queries, and is only delivered to the dev list.</p>
 
-<p>You've reached the end of the email. Pat yourself on the back.</p>
+<p>👋 You've reached the end of the email. Pat yourself on the back.</p>
 
 {{> foot }}

--- a/src/server/newsletters/templates/helloWorldText.hbs
+++ b/src/server/newsletters/templates/helloWorldText.hbs
@@ -1,0 +1,5 @@
+Hello.
+
+This is the Hello World newsletter. It has no real content, performs no database queries, and is only delivered to the dev list.
+
+👋 You've reached the end of the email. Pat yourself on the back.

--- a/src/server/newsletters/templates/partials/boilerplateBottom.hbs
+++ b/src/server/newsletters/templates/partials/boilerplateBottom.hbs
@@ -1,0 +1,11 @@
+<h3>About this email</h3>
+
+<p>Twitter statements are taken from selected Twitter feeds, such as national and state party organizations and endangered incumbents, including those lawmakers’ official campaign and congressional pages. These feeds often quote other sources and are sometimes written in the voice of staffers, so <mark>check the original post to verify attribution</mark>. CNN statements are taken from rush transcripts of yesterday’s CNN programs. Because the transcripts are done quickly, be sure to verify the accuracy of any quote or attribution against the video before using these statements in a fact-check.</p>
+
+<p>This automated email is part of an experimental alert service developed by the Tech &amp; Check Cooperative at the Duke Reporters’ Lab. It is strictly intended to help fact-checkers spot potentially newsworthy statements and claims. It is not for public distribution. No humans on the Tech &amp; Check team reviewed or verified these statements or their attribution before this alert was sent. ClaimBuster selected and ranked each statement algorithmically based on its potential checkability, not its factual accuracy. You can learn more about how ClaimBuster works here: <a href="http://idir-server2.uta.edu/claimbuster/">http://idir-server2.uta.edu/claimbuster/</a></p>
+
+<p>Please send any feedback to Tech &amp; Check project manager Erica Ryan (<a href="mailto:elryan@gmail.com">elryan@gmail.com</a>).</p>
+
+<p>Best,</p>
+
+<p><b>Duke Reporters’ Lab</b></p>

--- a/src/server/newsletters/templates/partials/boilerplateTop.hbs
+++ b/src/server/newsletters/templates/partials/boilerplateTop.hbs
@@ -1,0 +1,1 @@
+<p class="intro"><b>Good morning, fact-checkers!</b> This edition of our Tech &amp; Check Alerts features claims that the Duke Reporters’ Lab automatically scooped up and then prioritized using the ClaimBuster algorithm developed by our computer science partners at the University of Texas, Arlington.</p>

--- a/src/server/newsletters/templates/partials/foot.hbs
+++ b/src/server/newsletters/templates/partials/foot.hbs
@@ -1,0 +1,3 @@
+  </div>
+</body>
+</html>

--- a/src/server/newsletters/templates/partials/head.hbs
+++ b/src/server/newsletters/templates/partials/head.hbs
@@ -61,9 +61,10 @@
       color: inherit;
       text-decoration: underline;
     }
-      .claim__permalink:visited {
-        color: #999;
-      }
+
+    .claim__permalink:visited {
+      color: #999;
+    }
 
     .claim__speaker {
       font-weight: 600;
@@ -73,48 +74,48 @@
     .claim__platform {
       text-decoration: underline;
     }
-      a:hover .claim__platform {
-        text-decoration: none;
-      }
-      .claim[data-affiliation="CNN"] .claim__platform {
-        color: #c00;
-      }
-      .claim[data-affiliation="Fox"] .claim__platform {
-        color: #036;
-      }
-      .claim[data-affiliation="MSNBC"] .claim__platform {
-        color: #3062ff;
-      }
-      .claim[data-affiliation="Twitter"] .claim__platform {
-        color: #1da1f2;
-      }
-      .claim[data-affiliation="Facebook"] .claim__platform {
-        color: #3b5998;
-      }
+    a:hover .claim__platform {
+      text-decoration: none;
+    }
+    .claim[data-affiliation="CNN"] .claim__platform {
+      color: #c00;
+    }
+    .claim[data-affiliation="Fox"] .claim__platform {
+      color: #036;
+    }
+    .claim[data-affiliation="MSNBC"] .claim__platform {
+      color: #3062ff;
+    }
+    .claim[data-affiliation="Twitter"] .claim__platform {
+      color: #1da1f2;
+    }
+    .claim[data-affiliation="Facebook"] .claim__platform {
+      color: #3b5998;
+    }
 
     .claim__content {
       padding: 0 0 0 1em;
       margin: 0;
       border-left: 2px solid #ddd;
     }
-      .claim__content a:link {
-        color: inherit;
-      }
-      .claim[data-affiliation="CNN"] .claim__content {
-        border-color: #c00;
-      }
-      .claim[data-affiliation="Fox"] .claim__content {
-        border-color: #036;
-      }
-      .claim[data-affiliation="MSNBC"] .claim__content {
-        border-color: #3062ff;
-      }
-      .claim[data-affiliation="Twitter"] .claim__content {
-        border-color: #1da1f2;
-      }
-      .claim[data-affiliation="Facebook"] .claim__content {
-        border-color: #3b5998;
-      }
+    .claim__content a:link {
+      color: inherit;
+    }
+    .claim[data-affiliation="CNN"] .claim__content {
+      border-color: #c00;
+    }
+    .claim[data-affiliation="Fox"] .claim__content {
+      border-color: #036;
+    }
+    .claim[data-affiliation="MSNBC"] .claim__content {
+      border-color: #3062ff;
+    }
+    .claim[data-affiliation="Twitter"] .claim__content {
+      border-color: #1da1f2;
+    }
+    .claim[data-affiliation="Facebook"] .claim__content {
+      border-color: #3b5998;
+    }
 
     b {
       font-weight: 600;
@@ -128,6 +129,7 @@
       body {
         padding: 0;
       }
+
       #wrapper {
         box-shadow: none;
       }

--- a/src/server/newsletters/templates/partials/head.hbs
+++ b/src/server/newsletters/templates/partials/head.hbs
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <style>
+    body {
+      margin: 0;
+      padding: 0.5em 0.5em 2em;
+      font-size: 14px;
+      line-height: 1.6;
+      color: #111;
+      font-weight: normal;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      background-color: #eee;
+    }
+
+    #wrapper {
+      max-width: 50em;
+      background-color: white;
+      box-shadow: 4px 4px 0 #aaa;
+      padding: 1em;
+    }
+
+    .intro {
+      margin-top: 0;
+      font-size: 0.9em;
+      color: #666;
+    }
+
+    .claim-section {
+      margin: 3em 0;
+    }
+
+    .claim-section__header {
+      text-align: center;
+      font-size: 1.25em;
+      color: #333;
+      text-transform: uppercase;
+      margin: 0 0 1.5em;
+    }
+
+    .claims {
+      margin: 1.5em 0;
+      padding: 0;
+      list-style-type: none;
+    }
+
+    .claim {
+      padding: 0;
+      margin: 0 0 1.5em;
+    }
+
+    .claim__metadata {
+      margin-bottom: 0.25em;
+      color: #444;
+    }
+
+    .claim__permalink {
+      color: inherit;
+      text-decoration: underline;
+    }
+      .claim__permalink:visited {
+        color: #999;
+      }
+
+    .claim__speaker {
+      font-weight: 600;
+      font-style: inherit;
+    }
+
+    .claim__platform {
+      text-decoration: underline;
+    }
+      a:hover .claim__platform {
+        text-decoration: none;
+      }
+      .claim[data-affiliation="CNN"] .claim__platform {
+        color: #c00;
+      }
+      .claim[data-affiliation="Fox"] .claim__platform {
+        color: #036;
+      }
+      .claim[data-affiliation="MSNBC"] .claim__platform {
+        color: #3062ff;
+      }
+      .claim[data-affiliation="Twitter"] .claim__platform {
+        color: #1da1f2;
+      }
+      .claim[data-affiliation="Facebook"] .claim__platform {
+        color: #3b5998;
+      }
+
+    .claim__content {
+      padding: 0 0 0 1em;
+      margin: 0;
+      border-left: 2px solid #ddd;
+    }
+      .claim__content a:link {
+        color: inherit;
+      }
+      .claim[data-affiliation="CNN"] .claim__content {
+        border-color: #c00;
+      }
+      .claim[data-affiliation="Fox"] .claim__content {
+        border-color: #036;
+      }
+      .claim[data-affiliation="MSNBC"] .claim__content {
+        border-color: #3062ff;
+      }
+      .claim[data-affiliation="Twitter"] .claim__content {
+        border-color: #1da1f2;
+      }
+      .claim[data-affiliation="Facebook"] .claim__content {
+        border-color: #3b5998;
+      }
+
+    b {
+      font-weight: 600;
+    }
+
+    a:hover {
+      text-decoration: none;
+    }
+
+    @media only screen and (max-width: 480px) {
+      body {
+        padding: 0;
+      }
+      #wrapper {
+        box-shadow: none;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="wrapper">

--- a/src/server/newsletters/templates/partials/head.hbs
+++ b/src/server/newsletters/templates/partials/head.hbs
@@ -23,100 +23,6 @@
       padding: 1em;
     }
 
-    .intro {
-      margin-top: 0;
-      font-size: 0.9em;
-      color: #666;
-    }
-
-    .claim-section {
-      margin: 3em 0;
-    }
-
-    .claim-section__header {
-      text-align: center;
-      font-size: 1.25em;
-      color: #333;
-      text-transform: uppercase;
-      margin: 0 0 1.5em;
-    }
-
-    .claims {
-      margin: 1.5em 0;
-      padding: 0;
-      list-style-type: none;
-    }
-
-    .claim {
-      padding: 0;
-      margin: 0 0 1.5em;
-    }
-
-    .claim__metadata {
-      margin-bottom: 0.25em;
-      color: #444;
-    }
-
-    .claim__permalink {
-      color: inherit;
-      text-decoration: underline;
-    }
-
-    .claim__permalink:visited {
-      color: #999;
-    }
-
-    .claim__speaker {
-      font-weight: 600;
-      font-style: inherit;
-    }
-
-    .claim__platform {
-      text-decoration: underline;
-    }
-    a:hover .claim__platform {
-      text-decoration: none;
-    }
-    .claim[data-affiliation="CNN"] .claim__platform {
-      color: #c00;
-    }
-    .claim[data-affiliation="Fox"] .claim__platform {
-      color: #036;
-    }
-    .claim[data-affiliation="MSNBC"] .claim__platform {
-      color: #3062ff;
-    }
-    .claim[data-affiliation="Twitter"] .claim__platform {
-      color: #1da1f2;
-    }
-    .claim[data-affiliation="Facebook"] .claim__platform {
-      color: #3b5998;
-    }
-
-    .claim__content {
-      padding: 0 0 0 1em;
-      margin: 0;
-      border-left: 2px solid #ddd;
-    }
-    .claim__content a:link {
-      color: inherit;
-    }
-    .claim[data-affiliation="CNN"] .claim__content {
-      border-color: #c00;
-    }
-    .claim[data-affiliation="Fox"] .claim__content {
-      border-color: #036;
-    }
-    .claim[data-affiliation="MSNBC"] .claim__content {
-      border-color: #3062ff;
-    }
-    .claim[data-affiliation="Twitter"] .claim__content {
-      border-color: #1da1f2;
-    }
-    .claim[data-affiliation="Facebook"] .claim__content {
-      border-color: #3b5998;
-    }
-
     b {
       font-weight: 600;
     }
@@ -132,6 +38,7 @@
 
       #wrapper {
         box-shadow: none;
+        padding: 0.5em;
       }
     }
   </style>

--- a/src/server/utils/__test__/mailer.test.js
+++ b/src/server/utils/__test__/mailer.test.js
@@ -23,7 +23,9 @@ describe('utils/mailer', () => {
       expect(isMessageSendable({
         recipient: testData.recipient.valid[0],
         subject: testData.subject.valid[0],
-        bodyText: testData.bodyText.valid[0],
+        body: {
+          text: testData.body.text.valid[0],
+        },
       })).toBe(true)
     })
     it('Should reject invalid message data', () => {
@@ -31,21 +33,27 @@ describe('utils/mailer', () => {
         expect(isMessageSendable({
           recipient,
           subject: testData.subject.valid[0],
-          bodyText: testData.bodyText.valid[0],
+          body: {
+            text: testData.body.text.valid[0],
+          },
         })).toBe(false)
       })
       testData.subject.invalid.forEach((subject) => {
         expect(isMessageSendable({
           recipient: testData.recipient.valid[0],
           subject,
-          bodyText: testData.bodyText.valid[0],
+          body: {
+            text: testData.body.text.valid[0],
+          },
         })).toBe(false)
       })
-      testData.bodyText.invalid.forEach((body) => {
+      testData.body.text.invalid.forEach((text) => {
         expect(isMessageSendable({
           recipient: testData.recipient.valid[0],
           subject: testData.subject.valid[0],
-          body,
+          body: {
+            text,
+          },
         })).toBe(false)
       })
     })

--- a/src/server/utils/__test__/mailer.test.js
+++ b/src/server/utils/__test__/mailer.test.js
@@ -23,7 +23,7 @@ describe('utils/mailer', () => {
       expect(isMessageSendable({
         recipient: testData.recipient.valid[0],
         subject: testData.subject.valid[0],
-        body: testData.body.valid[0],
+        bodyText: testData.bodyText.valid[0],
       })).toBe(true)
     })
     it('Should reject invalid message data', () => {
@@ -31,17 +31,17 @@ describe('utils/mailer', () => {
         expect(isMessageSendable({
           recipient,
           subject: testData.subject.valid[0],
-          body: testData.body.valid[0],
+          bodyText: testData.bodyText.valid[0],
         })).toBe(false)
       })
       testData.subject.invalid.forEach((subject) => {
         expect(isMessageSendable({
           recipient: testData.recipient.valid[0],
           subject,
-          body: testData.body.valid[0],
+          bodyText: testData.bodyText.valid[0],
         })).toBe(false)
       })
-      testData.body.invalid.forEach((body) => {
+      testData.bodyText.invalid.forEach((body) => {
         expect(isMessageSendable({
           recipient: testData.recipient.valid[0],
           subject: testData.subject.valid[0],

--- a/src/server/utils/__test__/templates.test.js
+++ b/src/server/utils/__test__/templates.test.js
@@ -1,0 +1,62 @@
+import {
+  convertClaimNewsletterToText,
+  getHandlebarsTemplate,
+} from '../templates'
+
+const templateHTML = `
+<div id="wrapper">
+  <p>This is an intro!</p>
+  <div class="claim-section">
+    <h1 class="claim-section__header">🔎 Testing Claims 🔍</h1>
+    <ul class="claims">
+      <li class="claim" data-affiliation="CNN">
+        <div class="claim__metadata">
+          <a href="#" class="claim__permalink">
+            <cite class="claim__speaker">RAY BOYD</cite>
+            <span class="claim__platform">(<b>CNN</b>)</span></a>:
+        </div>
+        <blockquote class="claim__content">The human head weighs eight pounds.</blockquote>
+      </li>
+      <li class="claim" data-affiliation="Fox">
+        <div class="claim__metadata">
+          <a href="#" class="claim__permalink">
+            <cite class="claim__speaker">RAY BOYD</cite>
+            <span class="claim__platform">(<b>Fox</b>)</span></a>:
+        </div>
+        <blockquote class="claim__content">The human head does not weigh eight pounds.</blockquote>
+      </li>
+    </ul>
+  </div>
+  <p>Well that about wraps it up.</p>
+</div>
+`
+
+const templateText = `This is an intro!
+
+🔎 Testing Claims 🔍
+
+RAY BOYD (CNN):
+> The human head weighs eight pounds.
+
+RAY BOYD (Fox):
+> The human head does not weigh eight pounds.
+
+Well that about wraps it up.`
+
+describe('utils/templates', () => {
+  describe('getHandlebarsTemplate', () => {
+    const templateFn = getHandlebarsTemplate('Hello')
+    it('Should generate a handlebars template function given valid source', () => {
+      expect(templateFn).toBeInstanceOf(Function)
+    })
+    it('Should generate a handlebars template function that actually renders a template', () => {
+      expect(templateFn()).toBe('Hello')
+    })
+  })
+  describe('convertClaimNewsletterToText', () => {
+    it('Should convert claim HTML to text as expected', () => {
+      const convertedText = convertClaimNewsletterToText(templateHTML)
+      expect(convertedText).toEqual(templateText)
+    })
+  })
+})

--- a/src/server/utils/__test__/templates.test.js
+++ b/src/server/utils/__test__/templates.test.js
@@ -1,9 +1,17 @@
 import {
   convertClaimNewsletterToText,
   getHandlebarsTemplate,
+  stripHTMLTags,
 } from '../templates'
 
-const templateHTML = `
+const templateTestData = {
+  sanitizing: {
+    simple: {
+      original: '<p>This is a paragraph with some <b>bold text</b> and a <a href="#">link to something</a>.</p>',
+      sanitized: 'This is a paragraph with some bold text and a link to something.',
+    },
+    complex: {
+      original: `
 <div id="wrapper">
   <p>This is an intro!</p>
   <div class="claim-section">
@@ -29,19 +37,21 @@ const templateHTML = `
   </div>
   <p>Well that about wraps it up.</p>
 </div>
-`
-
-const templateText = `This is an intro!
+`,
+      sanitized: `This is an intro!
 
 🔎 Testing Claims 🔍
 
 RAY BOYD (CNN):
-> The human head weighs eight pounds.
+The human head weighs eight pounds.
 
 RAY BOYD (Fox):
-> The human head does not weigh eight pounds.
+The human head does not weigh eight pounds.
 
-Well that about wraps it up.`
+Well that about wraps it up.`,
+    },
+  },
+}
 
 describe('utils/templates', () => {
   describe('getHandlebarsTemplate', () => {
@@ -55,8 +65,24 @@ describe('utils/templates', () => {
   })
   describe('convertClaimNewsletterToText', () => {
     it('Should convert claim HTML to text as expected', () => {
-      const convertedText = convertClaimNewsletterToText(templateHTML)
-      expect(convertedText).toEqual(templateText)
+      const {
+        sanitizing: {
+          complex: { original, sanitized },
+        },
+      } = templateTestData
+      const convertedText = convertClaimNewsletterToText(original)
+      expect(convertedText).toEqual(sanitized)
+    })
+  })
+  describe('stripHTMLTags', () => {
+    it('Should strip HTML tags', () => {
+      const {
+        sanitizing: {
+          simple: { original, sanitized },
+        },
+      } = templateTestData
+      const convertedText = stripHTMLTags(original)
+      expect(convertedText).toEqual(sanitized)
     })
   })
 })

--- a/src/server/utils/mailer.js
+++ b/src/server/utils/mailer.js
@@ -6,12 +6,12 @@ export const isValidEmailAddressFormat = (emailAddress) => {
 export const isMessageSendable = (mail) => {
   const hasValidRecipient = recipient => isValidEmailAddressFormat(recipient)
   const hasValidSubject = subject => !!subject && typeof subject === 'string'
-  const hasValidBody = body => !!body && typeof body === 'string'
+  const hasValidBodyText = bodyText => !!bodyText && typeof bodyText === 'string'
 
   return (
     hasValidRecipient(mail.recipient)
     && hasValidSubject(mail.subject)
-    && hasValidBody(mail.body)
+    && hasValidBodyText(mail.bodyText)
   )
 }
 

--- a/src/server/utils/mailer.js
+++ b/src/server/utils/mailer.js
@@ -6,12 +6,12 @@ export const isValidEmailAddressFormat = (emailAddress) => {
 export const isMessageSendable = (mail) => {
   const hasValidRecipient = recipient => isValidEmailAddressFormat(recipient)
   const hasValidSubject = subject => !!subject && typeof subject === 'string'
-  const hasValidBodyText = bodyText => !!bodyText && typeof bodyText === 'string'
+  const hasValidBody = body => !!body.text && typeof body.text === 'string'
 
   return (
     hasValidRecipient(mail.recipient)
     && hasValidSubject(mail.subject)
-    && hasValidBodyText(mail.bodyText)
+    && hasValidBody(mail.body)
   )
 }
 

--- a/src/server/utils/templates.js
+++ b/src/server/utils/templates.js
@@ -1,5 +1,61 @@
-// Disabling because we intend to have more exports in the future.
-/* eslint-disable import/prefer-default-export */
+import fs from 'fs'
 import Handlebars from 'handlebars'
+import sanitizeHTML from 'sanitize-html'
 
-export const getHandlebarsTemplate = templateSource => Handlebars.compile(templateSource)
+import { getFileContents } from '.'
+
+const TEMPLATE_PARTIALS_DIRECTORY = `${__dirname}/../newsletters/templates/partials/`
+
+const isHandlebarsTemplate = fileName => fileName.endsWith('.hbs')
+
+const getHandlebarsPartials = () => fs.readdirSync(TEMPLATE_PARTIALS_DIRECTORY)
+  .filter(fileName => isHandlebarsTemplate(fileName))
+
+const registerHandlebarsPartial = (fileName) => {
+  const templateSource = getFileContents(`${TEMPLATE_PARTIALS_DIRECTORY}/${fileName}`)
+  const partialName = fileName.replace('.hbs', '')
+  Handlebars.registerPartial(partialName, templateSource)
+}
+
+const registerHandlebarsPartials = () => {
+  const partials = getHandlebarsPartials()
+  return partials.map(registerHandlebarsPartial)
+}
+
+export const getHandlebarsTemplate = (templateSource) => {
+  registerHandlebarsPartials()
+  return Handlebars.compile(templateSource)
+}
+
+export const convertClaimNewsletterToText = (templateHTML) => {
+  const stripHTMLTags = html => sanitizeHTML(html, {
+    allowedTags: [],
+    parser: {
+      decodeEntities: true,
+    },
+  })
+  const removeRepetitiveSpaces = text => text.replace(/ {2,}/g, ' ')
+  const removeTrailingSpaces = text => text.replace(/ \n/g, '\n')
+  const removeLeadingSpaces = text => text.replace(/\n /g, '\n')
+  const reduceMultipleNewlines = text => text.replace(/\n{3,}/g, '\n\n')
+  const inlinePlatform = text => text.replace(/\n\(/g, ' (')
+  const quoteContent = text => text.replace(/:\n\n/g, ':\n> ')
+  // `decodeAmpersands()` should be unnecessary, but sanitizeHTML's `decodeEntities` doesn't work
+  const decodeAmpersands = text => text.replace(/&amp;/g, '&')
+  const trimOuter = text => text.trim()
+
+  const conversionSequence = [
+    stripHTMLTags,
+    removeRepetitiveSpaces,
+    removeTrailingSpaces,
+    removeLeadingSpaces,
+    reduceMultipleNewlines,
+    inlinePlatform,
+    quoteContent,
+    decodeAmpersands,
+    trimOuter,
+  ] // Note that order does matter here
+
+  const templateText = conversionSequence.reduce((string, fn) => fn(string), templateHTML)
+  return templateText
+}

--- a/src/server/utils/templates.js
+++ b/src/server/utils/templates.js
@@ -27,19 +27,20 @@ export const getHandlebarsTemplate = (templateSource) => {
   return Handlebars.compile(templateSource)
 }
 
+export const stripHTMLTags = html => sanitizeHTML(html, {
+  allowedTags: [],
+  parser: {
+    decodeEntities: true,
+  },
+})
+
 export const convertClaimNewsletterToText = (templateHTML) => {
-  const stripHTMLTags = html => sanitizeHTML(html, {
-    allowedTags: [],
-    parser: {
-      decodeEntities: true,
-    },
-  })
   const removeRepetitiveSpaces = text => text.replace(/ {2,}/g, ' ')
   const removeTrailingSpaces = text => text.replace(/ \n/g, '\n')
   const removeLeadingSpaces = text => text.replace(/\n /g, '\n')
   const reduceMultipleNewlines = text => text.replace(/\n{3,}/g, '\n\n')
   const inlinePlatform = text => text.replace(/\n\(/g, ' (')
-  const quoteContent = text => text.replace(/:\n\n/g, ':\n> ')
+  const removeNewlinesBeforeContent = text => text.replace(/\):\n\n/g, '):\n')
   // `decodeAmpersands()` should be unnecessary, but sanitizeHTML's `decodeEntities` doesn't work
   const decodeAmpersands = text => text.replace(/&amp;/g, '&')
   const trimOuter = text => text.trim()
@@ -51,7 +52,7 @@ export const convertClaimNewsletterToText = (templateHTML) => {
     removeLeadingSpaces,
     reduceMultipleNewlines,
     inlinePlatform,
-    quoteContent,
+    removeNewlinesBeforeContent,
     decodeAmpersands,
     trimOuter,
   ] // Note that order does matter here

--- a/src/server/workers/mailer/Mailer.js
+++ b/src/server/workers/mailer/Mailer.js
@@ -20,17 +20,16 @@ class Mailer {
     const { mailgun } = this
 
     if (!isMessageSendable(message)) {
-      throw new Error('Mailer requires a message object with a valid recipient, subject, and bodyText.')
+      throw new Error('Mailer requires a message object with a valid recipient, subject, and body text.')
     }
 
     const mailgunData = {
       from: MAILER_FROM_ADDRESS,
       to: message.recipient,
       subject: message.subject,
-      text: message.bodyText,
+      text: message.body.text,
     }
-    // Only include HTML if we generated some
-    if (message.bodyHTML) mailgunData.html = message.bodyHTML
+    if (message.body.html) mailgunData.html = message.body.html
 
     const messageDescription = `"${mailgunData.subject}" from "${mailgunData.from}" to "${mailgunData.to}"`
 

--- a/src/server/workers/mailer/Mailer.js
+++ b/src/server/workers/mailer/Mailer.js
@@ -20,15 +20,17 @@ class Mailer {
     const { mailgun } = this
 
     if (!isMessageSendable(message)) {
-      throw new Error('Mailer requires a message object with a valid recipient, subject, and body.')
+      throw new Error('Mailer requires a message object with a valid recipient, subject, and bodyText.')
     }
 
     const mailgunData = {
       from: MAILER_FROM_ADDRESS,
       to: message.recipient,
       subject: message.subject,
-      text: message.body,
+      text: message.bodyText,
     }
+    // Only include HTML if we generated some
+    if (message.bodyHTML) mailgunData.html = message.bodyHTML
 
     const messageDescription = `"${mailgunData.subject}" from "${mailgunData.from}" to "${mailgunData.to}"`
 

--- a/src/server/workers/mailer/__test__/Mailer.test.js
+++ b/src/server/workers/mailer/__test__/Mailer.test.js
@@ -21,17 +21,17 @@ describe('Mailer', () => {
       expect(() => mailer.send({
         recipient,
         subject: testData.subject.valid[0],
-        body: testData.body.valid[0],
+        bodyText: testData.bodyText.valid[0],
       })).toThrow(Error)
     })
     testData.subject.invalid.forEach((subject) => {
       expect(() => mailer.send({
         recipient: testData.recipient.valid[0],
         subject,
-        body: testData.body.valid[0],
+        bodyText: testData.bodyText.valid[0],
       })).toThrow(Error)
     })
-    testData.body.invalid.forEach((body) => {
+    testData.bodyText.invalid.forEach((body) => {
       expect(() => mailer.send({
         recipient: testData.recipient.valid[0],
         subject: testData.subject.valid[0],
@@ -47,7 +47,7 @@ describe('Mailer', () => {
       mailer.send({
         recipient: testData.recipient.valid[0],
         subject: testData.subject.valid[0],
-        body: testData.body.valid[0],
+        bodyText: testData.bodyText.valid[0],
       })
       done()
     }

--- a/src/server/workers/mailer/__test__/Mailer.test.js
+++ b/src/server/workers/mailer/__test__/Mailer.test.js
@@ -21,21 +21,27 @@ describe('Mailer', () => {
       expect(() => mailer.send({
         recipient,
         subject: testData.subject.valid[0],
-        bodyText: testData.bodyText.valid[0],
+        body: {
+          text: testData.body.text.valid[0],
+        },
       })).toThrow(Error)
     })
     testData.subject.invalid.forEach((subject) => {
       expect(() => mailer.send({
         recipient: testData.recipient.valid[0],
         subject,
-        bodyText: testData.bodyText.valid[0],
+        body: {
+          text: testData.body.text.valid[0],
+        },
       })).toThrow(Error)
     })
-    testData.bodyText.invalid.forEach((body) => {
+    testData.body.text.invalid.forEach((text) => {
       expect(() => mailer.send({
         recipient: testData.recipient.valid[0],
         subject: testData.subject.valid[0],
-        body,
+        body: {
+          text,
+        },
       })).toThrow(Error)
     })
   })
@@ -47,7 +53,9 @@ describe('Mailer', () => {
       mailer.send({
         recipient: testData.recipient.valid[0],
         subject: testData.subject.valid[0],
-        bodyText: testData.bodyText.valid[0],
+        body: {
+          text: testData.body.text.valid[0],
+        },
       })
       done()
     }

--- a/src/server/workers/mailer/__test__/mailerTestData.js
+++ b/src/server/workers/mailer/__test__/mailerTestData.js
@@ -18,7 +18,7 @@ export default {
     valid: ['You are invited.'],
     invalid: ['', 1, false],
   },
-  body: {
+  bodyText: {
     valid: ['You are invited by anyone to do anything, you are invited for all time. You are so needed by everyone to do everything, you are invited for all time...'],
     invalid: ['', 1, false],
   },

--- a/src/server/workers/mailer/__test__/mailerTestData.js
+++ b/src/server/workers/mailer/__test__/mailerTestData.js
@@ -18,8 +18,10 @@ export default {
     valid: ['You are invited.'],
     invalid: ['', 1, false],
   },
-  bodyText: {
-    valid: ['You are invited by anyone to do anything, you are invited for all time. You are so needed by everyone to do everything, you are invited for all time...'],
-    invalid: ['', 1, false],
+  body: {
+    text: {
+      valid: ['You are invited by anyone to do anything, you are invited for all time. You are so needed by everyone to do everything, you are invited for all time...'],
+      invalid: ['', 1, false],
+    },
   },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1309,6 +1309,11 @@ array-includes@^3.0.3:
     define-properties "^1.1.2"
     es-abstract "^1.7.0"
 
+array-uniq@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+  integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
+
 array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
@@ -3799,7 +3804,7 @@ htmlnano@^0.2.2:
     terser "^3.16.1"
     uncss "^0.16.2"
 
-htmlparser2@^3.9.1, htmlparser2@^3.9.2:
+htmlparser2@^3.10.0, htmlparser2@^3.9.1, htmlparser2@^3.9.2:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
   integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
@@ -4970,20 +4975,45 @@ lodash.clone@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
   integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
 lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
   integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
+
+lodash.escaperegexp@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
+  integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
 
 lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.mergewith@^4.6.1:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -7192,6 +7222,22 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
+sanitize-html@^1.20.1:
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.20.1.tgz#f6effdf55dd398807171215a62bfc21811bacf85"
+  integrity sha512-txnH8TQjaQvg2Q0HY06G6CDJLVYCpbnxrdO0WN8gjCKaU5J0KbyGYhZxx5QJg3WLZ1lB7XU9kDkfrCXUozqptA==
+  dependencies:
+    chalk "^2.4.1"
+    htmlparser2 "^3.10.0"
+    lodash.clonedeep "^4.5.0"
+    lodash.escaperegexp "^4.1.2"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.mergewith "^4.6.1"
+    postcss "^7.0.5"
+    srcset "^1.0.0"
+    xtend "^4.0.1"
+
 sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -7524,6 +7570,14 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+srcset@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/srcset/-/srcset-1.0.0.tgz#a5669de12b42f3b1d5e83ed03c71046fc48f41ef"
+  integrity sha1-pWad4StC87HV6D7QPHEEb8SPQe8=
+  dependencies:
+    array-uniq "^1.0.2"
+    number-is-nan "^1.0.0"
 
 sshpk@^1.7.0:
   version "1.16.1"
@@ -8468,6 +8522,11 @@ xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
   integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
+
+xtend@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 "y18n@^3.2.1 || ^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
* Import current designs (#28) and email boilerplate
* Automatically register Handlebars partials
* Apply design to Hello World newsletter
* Add Mailer support for HTML and text bodies
* Generate text versions of newsletters by stripping out the HTML
* Modify Hello World newsletter to include claim speakers

Note that the design and newsletter boilerplate will change in the future, and the claim/speaker association will change significantly once #88 is merged in.

Closes #29