### PR TITLE
Expand on claim / statement metadata

### DIFF
--- a/src/server/constants.js
+++ b/src/server/constants.js
@@ -5,3 +5,8 @@ export const ENV_NAMES = {
 }
 
 export const CLAIMBUSTER_THRESHHOLD = 0.5
+
+// Every property of this object should have a corresponding property on `STATEMENT_SCRAPER_NAMES`
+export const CLAIM_PLATFORM_NAMES = {
+  CNN_TRANSCRIPT: 'CNN',
+}

--- a/src/server/migrations/20190809032905-rename-scraper-code.js
+++ b/src/server/migrations/20190809032905-rename-scraper-code.js
@@ -1,0 +1,4 @@
+module.exports = {
+  up: queryInterface => queryInterface.renameColumn('claims', 'scraper_code', 'scraper_name'),
+  down: queryInterface => queryInterface.renameColumn('claims', 'scraper_name', 'scraper_code'),
+}

--- a/src/server/models/claim.js
+++ b/src/server/models/claim.js
@@ -3,7 +3,7 @@ module.exports = (sequelize, DataTypes) => {
     content: DataTypes.TEXT,
     claimedAt: DataTypes.DATE,
     canonicalUrl: DataTypes.STRING(1024),
-    scraperCode: DataTypes.STRING(1024), // The scraper that generated this claim
+    scraperName: DataTypes.STRING(1024), // The scraper that generated this claim
     source: DataTypes.STRING(1024),
     speakerName: DataTypes.STRING(1024),
     speakerAffiliation: DataTypes.STRING(1024),

--- a/src/server/newsletters/templates/national.hbs
+++ b/src/server/newsletters/templates/national.hbs
@@ -5,12 +5,13 @@
   <h1 class="claim-section__header">📺 TV Claims 📺</h1>
   <ul class="claims">
   {{#each tvClaims}}
-    <li class="claim">
+    <li class="claim" data-platform="{{convertScraperCodeToPlatformName scraperCode}}">
       <div class="claim__metadata">
         <a href="{{canonicalUrl}}" class="claim__permalink">
           <cite class="claim__speaker">
             {{speakerName}}
-          </cite></a>:
+          </cite>
+          <span class="claim__platform">({{convertScraperCodeToPlatformName scraperCode}})</span></a>:
       </div>
       <blockquote class="claim__content">{{content}}</blockquote>
     </li>

--- a/src/server/newsletters/templates/national.hbs
+++ b/src/server/newsletters/templates/national.hbs
@@ -5,13 +5,13 @@
   <h1 class="claim-section__header">📺 TV Claims 📺</h1>
   <ul class="claims">
   {{#each tvClaims}}
-    <li class="claim" data-platform="{{convertScraperCodeToPlatformName scraperCode}}">
+    <li class="claim" data-platform="{{convertScraperNameToPlatformName scraperName}}">
       <div class="claim__metadata">
         <a href="{{canonicalUrl}}" class="claim__permalink">
           <cite class="claim__speaker">
             {{speakerName}}
           </cite>
-          <span class="claim__platform">({{convertScraperCodeToPlatformName scraperCode}})</span></a>:
+          <span class="claim__platform">({{convertScraperNameToPlatformName scraperName}})</span></a>:
       </div>
       <blockquote class="claim__content">{{content}}</blockquote>
     </li>

--- a/src/server/newsletters/templates/nationalText.hbs
+++ b/src/server/newsletters/templates/nationalText.hbs
@@ -5,7 +5,7 @@
 📺 TV CLAIMS 📺
 {{#each tvClaims}}
 
-{{speakerName}} ({{convertScraperCodeToPlatformName scraperCode}}):
+{{speakerName}} ({{convertScraperNameToPlatformName scraperName}}):
 {{ content }}
 — {{canonicalUrl}}
 {{/each}}

--- a/src/server/newsletters/templates/nationalText.hbs
+++ b/src/server/newsletters/templates/nationalText.hbs
@@ -5,7 +5,7 @@
 📺 TV CLAIMS 📺
 {{#each tvClaims}}
 
-{{speakerName}}:
+{{speakerName}} ({{convertScraperCodeToPlatformName scraperCode}}):
 {{ content }}
 — {{canonicalUrl}}
 {{/each}}

--- a/src/server/queues/claimBusterClaimDetectorQueue/claimBusterClaimDetectorJobProcessor.js
+++ b/src/server/queues/claimBusterClaimDetectorQueue/claimBusterClaimDetectorJobProcessor.js
@@ -9,6 +9,8 @@ const saveClaim = async claim => Claim.create({
   claimBusterScore: claim.score,
   speakerName: claim.speaker.name,
   speakerAffiliation: claim.speaker.affiliation,
+  canonicalUrl: claim.canonicalUrl,
+  scraperCode: claim.scraperCode,
 })
 
 export default async (job) => {

--- a/src/server/queues/claimBusterClaimDetectorQueue/claimBusterClaimDetectorJobProcessor.js
+++ b/src/server/queues/claimBusterClaimDetectorQueue/claimBusterClaimDetectorJobProcessor.js
@@ -7,6 +7,8 @@ const { Claim } = models
 const saveClaim = async claim => Claim.create({
   content: claim.text,
   claimBusterScore: claim.score,
+  speakerName: claim.speaker.name,
+  speakerAffiliation: claim.speaker.affiliation,
 })
 
 export default async (job) => {

--- a/src/server/queues/claimBusterClaimDetectorQueue/claimBusterClaimDetectorJobProcessor.js
+++ b/src/server/queues/claimBusterClaimDetectorQueue/claimBusterClaimDetectorJobProcessor.js
@@ -10,7 +10,7 @@ const saveClaim = async claim => Claim.create({
   speakerName: claim.speaker.name,
   speakerAffiliation: claim.speaker.affiliation,
   canonicalUrl: claim.canonicalUrl,
-  scraperCode: claim.scraperCode,
+  scraperName: claim.scraperName,
 })
 
 export default async (job) => {

--- a/src/server/utils/templates.js
+++ b/src/server/utils/templates.js
@@ -27,9 +27,9 @@ const registerHandlebarsPartial = (fileName) => {
 }
 
 const registerHandlebarsHelpers = () => {
-  Handlebars.registerHelper('convertScraperCodeToPlatformName', (scraperCode) => {
+  Handlebars.registerHelper('convertScraperNameToPlatformName', (scraperName) => {
     const sharedKey = Object.keys(STATEMENT_SCRAPER_NAMES)
-      .find(scraperNameKey => STATEMENT_SCRAPER_NAMES[scraperNameKey] === scraperCode)
+      .find(scraperNameKey => STATEMENT_SCRAPER_NAMES[scraperNameKey] === scraperName)
     return CLAIM_PLATFORM_NAMES[sharedKey]
   })
 }

--- a/src/server/utils/templates.js
+++ b/src/server/utils/templates.js
@@ -3,6 +3,12 @@ import Handlebars from 'handlebars'
 import sanitizeHTML from 'sanitize-html'
 
 import {
+  CLAIM_PLATFORM_NAMES,
+} from '../constants'
+import {
+  STATEMENT_SCRAPER_NAMES,
+} from '../workers/scrapers/constants'
+import {
   getFileContents,
   runSequence,
 } from '.'
@@ -20,12 +26,21 @@ const registerHandlebarsPartial = (fileName) => {
   Handlebars.registerPartial(partialName, templateSource)
 }
 
+const registerHandlebarsHelpers = () => {
+  Handlebars.registerHelper('convertScraperCodeToPlatformName', (scraperCode) => {
+    const sharedKey = Object.keys(STATEMENT_SCRAPER_NAMES)
+      .find(scraperNameKey => STATEMENT_SCRAPER_NAMES[scraperNameKey] === scraperCode)
+    return CLAIM_PLATFORM_NAMES[sharedKey]
+  })
+}
+
 const registerHandlebarsPartials = () => {
   const partials = getHandlebarsPartials()
   return partials.map(registerHandlebarsPartial)
 }
 
 export const getHandlebarsTemplate = (templateSource) => {
+  registerHandlebarsHelpers()
   registerHandlebarsPartials()
   return Handlebars.compile(templateSource)
 }

--- a/src/server/workers/claimDetectors/ClaimBusterClaimDetector.js
+++ b/src/server/workers/claimDetectors/ClaimBusterClaimDetector.js
@@ -11,7 +11,7 @@ class ClaimBusterClaimDetector {
       speaker,
       text: statementText,
       canonicalUrl,
-      scraperCode,
+      scraperName,
     } = this.statement
     const uri = `https://idir.uta.edu/factchecker/score_text/${statementText}`
     return rp
@@ -25,7 +25,7 @@ class ClaimBusterClaimDetector {
           text: result.text,
           score: result.score,
           canonicalUrl,
-          scraperCode,
+          scraperName,
         })))
   }
 }

--- a/src/server/workers/claimDetectors/ClaimBusterClaimDetector.js
+++ b/src/server/workers/claimDetectors/ClaimBusterClaimDetector.js
@@ -10,6 +10,8 @@ class ClaimBusterClaimDetector {
     const {
       speaker,
       text: statementText,
+      canonicalUrl,
+      scraperCode,
     } = this.statement
     const uri = `https://idir.uta.edu/factchecker/score_text/${statementText}`
     return rp
@@ -22,6 +24,8 @@ class ClaimBusterClaimDetector {
           speaker,
           text: result.text,
           score: result.score,
+          canonicalUrl,
+          scraperCode,
         })))
   }
 }

--- a/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
+++ b/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
@@ -40,7 +40,7 @@ class CnnTranscriptStatementScraper extends AbstractStatementScraper {
   }
 
   addScraperNameToStatements = statements => statements
-    .map(statement => ({ ...statement, scraperName: STATEMENT_SCRAPER_NAMES.CNN_TRANSCRIPT }))
+    .map(statement => ({ ...statement, scraperCode: STATEMENT_SCRAPER_NAMES.CNN_TRANSCRIPT }))
 
   addCanonicalUrlToStatements = statements => statements
     .map(statement => ({ ...statement, canonicalUrl: this.scrapeUrl }))

--- a/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
+++ b/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
@@ -40,7 +40,7 @@ class CnnTranscriptStatementScraper extends AbstractStatementScraper {
   }
 
   addScraperNameToStatements = statements => statements
-    .map(statement => ({ ...statement, scraperCode: STATEMENT_SCRAPER_NAMES.CNN_TRANSCRIPT }))
+    .map(statement => ({ ...statement, scraperName: STATEMENT_SCRAPER_NAMES.CNN_TRANSCRIPT }))
 
   addCanonicalUrlToStatements = statements => statements
     .map(statement => ({ ...statement, canonicalUrl: this.scrapeUrl }))

--- a/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
+++ b/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
@@ -1,5 +1,7 @@
 import cheerio from 'cheerio'
 
+import { STATEMENT_SCRAPER_NAMES } from './constants'
+
 import {
   isTranscriptUrl,
   getFullCnnUrl,
@@ -37,6 +39,12 @@ class CnnTranscriptStatementScraper extends AbstractStatementScraper {
     return bodyTexts[2]
   }
 
+  addScraperNameToStatements = statements => statements
+    .map(statement => ({ ...statement, scraperName: STATEMENT_SCRAPER_NAMES.CNN_TRANSCRIPT }))
+
+  addCanonicalUrlToStatements = statements => statements
+    .map(statement => ({ ...statement, canonicalUrl: this.scrapeUrl }))
+
   extractStatementsFromTranscript = (transcript) => {
     const stepSequence = [
       removeTimestamps,
@@ -49,6 +57,8 @@ class CnnTranscriptStatementScraper extends AbstractStatementScraper {
       removeUnattributableStatements,
       cleanStatementSpeakerNames,
       normalizeStatementSpeakers,
+      this.addScraperNameToStatements,
+      this.addCanonicalUrlToStatements,
     ] // Note that order does matter here
 
     const statements = stepSequence.reduce((string, fn) => fn(string), transcript)

--- a/src/server/workers/scrapers/constants.js
+++ b/src/server/workers/scrapers/constants.js
@@ -1,0 +1,6 @@
+// Disabling because we intend to have more exports in the future.
+/* eslint-disable import/prefer-default-export */
+
+export const STATEMENT_SCRAPER_NAMES = {
+  CNN_TRANSCRIPT: 'cnnTranscript',
+}

--- a/src/server/workers/scrapers/constants.js
+++ b/src/server/workers/scrapers/constants.js
@@ -1,6 +1,7 @@
 // Disabling because we intend to have more exports in the future.
 /* eslint-disable import/prefer-default-export */
 
+// Every property of this object should have a corresponding property on `CLAIM_PLATFORM_NAMES`
 export const STATEMENT_SCRAPER_NAMES = {
   CNN_TRANSCRIPT: 'cnnTranscript',
 }


### PR DESCRIPTION
This inserts speaker name / affiliation into claims, and also exposes the URL and scraper name to statements (which can then be added to claims in a later commit)

Related to #99 