### PR TITLE
Allow for numbers in speaker affiliations

### DIFF
--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -165,6 +165,8 @@ describe('utils/cnn', () => {
         .toEqual('DONNA, SLAYER OF CAKES')
       expect(getAttributionFromChunk('REV. AL SHARPTON (D), PRESIDENTIAL CANDIDATE: Schwarzenegger is an impostor. You will see at the end of this that I\'m the real Terminator. I want to terminate Bush.'))
         .toEqual('REV. AL SHARPTON (D), PRESIDENTIAL CANDIDATE')
+      expect(getAttributionFromChunk('BILL CLINTON, 42ND PRESIDENT OF THE UNITED STATES: Beep beep boop.'))
+        .toEqual('BILL CLINTON, 42ND PRESIDENT OF THE UNITED STATES')
     })
     it('Should return an empty attribution if none exists', () => {
       expect(getAttributionFromChunk('This has no attribution'))
@@ -191,6 +193,8 @@ describe('utils/cnn', () => {
         .toEqual('DONNA')
       expect(getNameFromAttribution('DONNA LITTLE, SLAYER OF CAKES'))
         .toEqual('DONNA LITTLE')
+      expect(getNameFromAttribution('BILL CLINTON, 42ND PRESIDENT OF THE UNITED STATES'))
+        .toEqual('BILL CLINTON')
     })
     it('Should return an empty name if there is no attribution', () => {
       expect(getNameFromAttribution(''))
@@ -208,6 +212,8 @@ describe('utils/cnn', () => {
         .toEqual('SLAYER OF "CAKES"')
       expect(getAffiliationFromAttribution('DONNA LITTLE, SLAYER OF "CAKES" (RETIRED)'))
         .toEqual('SLAYER OF "CAKES" (RETIRED)')
+      expect(getAffiliationFromAttribution('BILL CLINTON, 42ND PRESIDENT OF THE UNITED STATES'))
+        .toEqual('42ND PRESIDENT OF THE UNITED STATES')
     })
     it('Should return an empty affiliation if there is no affiliation', () => {
       expect(getAffiliationFromAttribution('DONNA'))

--- a/src/server/utils/cnn.js
+++ b/src/server/utils/cnn.js
@@ -10,6 +10,13 @@
  * @property {String}  text    What the person actually said
  */
 
+/**
+ * These expressions are used in various utility mehtods
+ * to identify special portions of scraped tex.
+ */
+const attributionaAffiliationRegex = /,([A-Z\d\s"(),]*)/
+const chunkAttributionRegex = /[A-Z\d\s"(),.]+[:]/
+
 export const isTranscriptListUrl = url => url.startsWith('/TRANSCRIPTS/')
   && url.endsWith('.html')
 
@@ -76,9 +83,6 @@ export const addBreaksOnSpeakerChange = transcript => transcript
  */
 export const splitTranscriptIntoChunks = transcript => transcript.split('\n')
 
-// Used to identify the speaker section of a chunk
-const chunkAttributionRegex = /[.,A-Z\s"()]+[:]/
-
 /**
  * Extract the speaker name / affiliation from a chunk.
  *
@@ -110,6 +114,7 @@ export const getNameFromAttribution = attribution => (
   (attribution.match(/[A-Z\s.()]+/)
   || [''])[0]
 )
+
 /**
  * Extract the person's affiliation from an attribution string.
  *
@@ -118,7 +123,7 @@ export const getNameFromAttribution = attribution => (
  *                                  the person's affiliation
  */
 export const getAffiliationFromAttribution = attribution => (
-  (attribution.match(/,([A-Z\s,"()]*)/)
+  (attribution.match(attributionaAffiliationRegex)
   || [','])[0]
     .substring(1)
     .trim()


### PR DESCRIPTION
This adds tests and support for speakers who have numbers in their affiliations.

Resolves #98