### PR TITLE
Switch attribution regex to negatives

### DIFF
--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -206,6 +206,14 @@ describe('utils/cnn', () => {
       expect(getNameFromAttribution(''))
         .toEqual('')
     })
+    it('Should extract names with apostrophes', () => {
+      expect(getNameFromAttribution('BETO O\'ROURKE (D), PRESIDENTIAL CANDIDATE'))
+        .toEqual('BETO O\'ROURKE (D)')
+    })
+    it('Should extract names with hyphens', () => {
+      expect(getNameFromAttribution('GOV. STEVE BULLOCK (D-MT), PRESIDENTIAL CANDIDATE'))
+        .toEqual('GOV. STEVE BULLOCK (D-MT)')
+    })
   })
 
   describe('getAffiliationFromAttribution', () => {

--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -172,6 +172,12 @@ describe('utils/cnn', () => {
       expect(getAttributionFromChunk('This has no attribution'))
         .toEqual('')
     })
+    it('Should not return non-attributions', () => {
+      expect(getAttributionFromChunk('ATTRIBUTION: this is: not an attribution: and neither is this.'))
+        .toEqual('ATTRIBUTION')
+      expect(getAttributionFromChunk('this is: not an attribution: and neither is this.'))
+        .toEqual('')
+    })
   })
 
   describe('getStatementFromChunk', () => {

--- a/src/server/utils/cnn.js
+++ b/src/server/utils/cnn.js
@@ -11,10 +11,11 @@
  */
 
 /**
- * These expressions are used in various utility mehtods
+ * These expressions are used in various utility methods
  * to identify special portions of scraped tex.
  */
 const attributionAffiliationRegex = /,([^a-z]*)/
+const attributionNameRegex = /[^a-z,]+/
 const chunkAttributionRegex = /[^a-z]+[:]/
 
 export const isTranscriptListUrl = url => url.startsWith('/TRANSCRIPTS/')
@@ -111,7 +112,7 @@ export const getStatementFromChunk = chunk => chunk
  * @return {String}             The portion of the attribution that contains the person's name
  */
 export const getNameFromAttribution = attribution => (
-  (attribution.match(/[A-Z\s.()]+/)
+  (attribution.match(attributionNameRegex)
   || [''])[0]
 )
 

--- a/src/server/utils/cnn.js
+++ b/src/server/utils/cnn.js
@@ -14,8 +14,8 @@
  * These expressions are used in various utility mehtods
  * to identify special portions of scraped tex.
  */
-const attributionaAffiliationRegex = /,([A-Z\d\s"(),]*)/
-const chunkAttributionRegex = /[A-Z\d\s"(),.]+[:]/
+const attributionAffiliationRegex = /,([^a-z]*)/
+const chunkAttributionRegex = /[^a-z]+[:]/
 
 export const isTranscriptListUrl = url => url.startsWith('/TRANSCRIPTS/')
   && url.endsWith('.html')
@@ -123,7 +123,7 @@ export const getNameFromAttribution = attribution => (
  *                                  the person's affiliation
  */
 export const getAffiliationFromAttribution = attribution => (
-  (attribution.match(attributionaAffiliationRegex)
+  (attribution.match(attributionAffiliationRegex)
   || [','])[0]
     .substring(1)
     .trim()


### PR DESCRIPTION
Instead of listing all of the things an attribution can contain, lets just list out all of the things it can't.  The simple rule is that attributions never have lower case letters.

Attribution, name, and affiliation now use this logic instead.  If we find false positives cropping up then we can move from there.

Resolves #113 
Resolves #107 