### PR TITLE
Return a default value when scraper-running fails

### DIFF
--- a/src/server/workers/scrapers/AbstractScraper.js
+++ b/src/server/workers/scrapers/AbstractScraper.js
@@ -142,10 +142,11 @@ class AbstractScraper {
         return result
       })
       .catch((err) => {
-        logger.debug(`Failed (${this.scrapeUrl})`)
+        logger.debug(`Failed (${this.scrapeUrl}), returning default value.`)
         logger.warn(err)
         this.registerScrapeError()
         this.storeScrapeError(err)
+        return []
       })
   }
 }


### PR DESCRIPTION
This modifies `AbstractScraper.run()` to return a default/empty array when the scraping itself fails, and expands upon the debug message to note that it’s happening.

This allows downstream code to be able to always expect an array (though we will still want to wrap it in a try/catch block for safety).

Resolves #115