### PR TITLE
Normalize speakers before removing affiliations

### DIFF
--- a/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
+++ b/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
@@ -53,10 +53,10 @@ class CnnTranscriptStatementScraper extends AbstractStatementScraper {
       addBreaksOnSpeakerChange,
       splitTranscriptIntoChunks,
       extractStatementsFromChunks,
-      removeNetworkAffiliatedStatements,
-      removeUnattributableStatements,
       cleanStatementSpeakerNames,
       normalizeStatementSpeakers,
+      removeNetworkAffiliatedStatements,
+      removeUnattributableStatements,
       this.addScraperNameToStatements,
       this.addCanonicalUrlToStatements,
     ] // Note that order does matter here


### PR DESCRIPTION
In the statement extraction pipeline we remove CNN affiliates.  We also normalize speakers so that last names and affiliations are applied to all speaker / statement pairs even if CNN truncates later in the transcript.  We were removing affiliated speakers BEFORE normalizing, meaning the normalization script did not have affiliations as part of the storage.

This changes the pipeline order so that normalization happens immediately after statements are extracted, and before any removal of "dud" statements.

Unfortunately we don't have integration tests set up for this pipeline, so there is no way to write a test as it goes beyond the functionality of individual utility methods.

Resolves #123