### PR TITLE
Rename getStatementFromChunk

### DIFF
--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -8,7 +8,7 @@ import {
   addBreaksOnSpeakerChange,
   splitTranscriptIntoChunks,
   getAttributionFromChunk,
-  getStatementFromChunk,
+  getTextFromChunk,
   getNameFromAttribution,
   getAffiliationFromAttribution,
   extractStatementFromChunk,
@@ -180,11 +180,11 @@ describe('utils/cnn', () => {
     })
   })
 
-  describe('getStatementFromChunk', () => {
+  describe('getTextFromChunk', () => {
     it('Should extract the statement from a chunk', () => {
-      expect(getStatementFromChunk('DONNA: My name is Donna.'))
+      expect(getTextFromChunk('DONNA: My name is Donna.'))
         .toEqual('My name is Donna.')
-      expect(getStatementFromChunk('DONNA, SLAYER OF CAKES: My name is Donna.'))
+      expect(getTextFromChunk('DONNA, SLAYER OF CAKES: My name is Donna.'))
         .toEqual('My name is Donna.')
     })
   })

--- a/src/server/utils/cnn.js
+++ b/src/server/utils/cnn.js
@@ -102,7 +102,7 @@ export const getAttributionFromChunk = chunk => (
  * @param  {String} chunk The segment of a transcript which contains a speaker and a statement.
  * @return {String}       The portion of the chunk that contains what was said.
  */
-export const getStatementFromChunk = chunk => chunk
+export const getTextFromChunk = chunk => chunk
   .replace(chunkAttributionRegex, '').trim()
 
 /**
@@ -138,7 +138,7 @@ export const getAffiliationFromAttribution = attribution => (
  */
 export const extractStatementFromChunk = (chunk) => {
   const attribution = getAttributionFromChunk(chunk)
-  const statement = getStatementFromChunk(chunk)
+  const text = getTextFromChunk(chunk)
   const name = getNameFromAttribution(attribution)
   const affiliation = getAffiliationFromAttribution(attribution)
 
@@ -147,7 +147,7 @@ export const extractStatementFromChunk = (chunk) => {
       name,
       affiliation,
     },
-    text: statement,
+    text,
   }
 }
 


### PR DESCRIPTION
Statement was an overloaded term and we fixed it (statement objects had a statement attribute).  We forgot to rename the helper methods when that rename happened.  This completes that fix by renaming getStatementFromChunk to getTextFromChunk.

Resolves #117