### PR TITLE
Correct line break insertion on speaker change

### DIFF
--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -147,12 +147,16 @@ describe('utils/cnn', () => {
         .toBe('JANE: testing.\nELIANA JOHNSON, NATIONAL POLITICAL REPORTER, "POLITICO": Testing')
     })
     it('Should not create line breaks for one speaker', () => {
-      expect(removeTimestamps('DONNA: Whoever it is they seem to be running out of ideas.'))
+      expect(addBreaksOnSpeakerChange('DONNA: Whoever it is they seem to be running out of ideas.'))
         .toBe('DONNA: Whoever it is they seem to be running out of ideas.')
     })
     it('Should not create line breaks for all-caps words', () => {
-      expect(removeTimestamps('PROGRAMMER: LOOK. WHAT DO YOU EXPECT.'))
+      expect(addBreaksOnSpeakerChange('PROGRAMMER: LOOK. WHAT DO YOU EXPECT.'))
         .toBe('PROGRAMMER: LOOK. WHAT DO YOU EXPECT.')
+    })
+    it('Should not include quotes from previous lines', () => {
+      expect(addBreaksOnSpeakerChange('"This is a quote." DONNA: Whoever it is they seem to be running out of ideas.'))
+        .toBe('"This is a quote."\nDONNA: Whoever it is they seem to be running out of ideas.')
     })
   })
 

--- a/src/server/utils/cnn.js
+++ b/src/server/utils/cnn.js
@@ -73,7 +73,7 @@ export const removeDescriptors = transcript => transcript
  * @return {String}            The modified transcript with line breaks inserted.
  */
 export const addBreaksOnSpeakerChange = transcript => transcript
-  .replace(/([.?!\-)\]])\s*([.,A-Z\s"()]*:)/g, '$1\n$2')
+  .replace(/([".?!\-)\]]+)\s*([.,A-Z\s"()]*:)/g, '$1\n$2')
 
 
 /**


### PR DESCRIPTION
Line breaks were not being inserted in the correct location in places where (1) there were quotes and (2) there were multiple forms of punctuation ending a chunk (e.g. a `."` or `")`).

This corrects that RegEx to insert chunk breaks in the right place.

Resolves #131