### PR TITLE
Clean affiliation names more effectively

### DIFF
--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -158,6 +158,10 @@ describe('utils/cnn', () => {
       expect(addBreaksOnSpeakerChange('"This is a quote." DONNA: Whoever it is they seem to be running out of ideas.'))
         .toBe('"This is a quote."\nDONNA: Whoever it is they seem to be running out of ideas.')
     })
+    it('Should allow for hyphens in affiliations', () => {
+      expect(addBreaksOnSpeakerChange('Testing this. SEN. ELIZABETH WARREN (D-MA), PRESIDENTIAL CANDIDATE: I do and if you know you think about the sorrow'))
+        .toBe('Testing this.\nSEN. ELIZABETH WARREN (D-MA), PRESIDENTIAL CANDIDATE: I do and if you know you think about the sorrow')
+    })
   })
 
   describe('splitTranscriptIntoChunks', () => {
@@ -344,6 +348,12 @@ describe('utils/cnn', () => {
       expect(cleanSpeakerName('SEN. JIMMY DUST'))
         .toBe('JIMMY DUST')
       expect(cleanSpeakerName('REPRESENTATIVE JIMMY DUST'))
+        .toBe('JIMMY DUST')
+    })
+    it('Should remove parentheticals', () => {
+      expect(cleanSpeakerName('JIMMY DUST (D-MA)'))
+        .toBe('JIMMY DUST')
+      expect(cleanSpeakerName('JIMMY DUST (THE MOST NOTORIOUS BOTANIST IN THE WEST)'))
         .toBe('JIMMY DUST')
     })
   })

--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -162,6 +162,10 @@ describe('utils/cnn', () => {
       expect(addBreaksOnSpeakerChange('Testing this. SEN. ELIZABETH WARREN (D-MA), PRESIDENTIAL CANDIDATE: I do and if you know you think about the sorrow'))
         .toBe('Testing this.\nSEN. ELIZABETH WARREN (D-MA), PRESIDENTIAL CANDIDATE: I do and if you know you think about the sorrow')
     })
+    it('Should allow for apostrophes in affiliations', () => {
+      expect(addBreaksOnSpeakerChange('(BEGIN VIDEOTAPE) BETO O\'ROURKE (D-TX), PRESIDENTIAL CANDIDATE: Yes.'))
+        .toBe('(BEGIN VIDEOTAPE)\nBETO O\'ROURKE (D-TX), PRESIDENTIAL CANDIDATE: Yes.')
+    })
   })
 
   describe('splitTranscriptIntoChunks', () => {

--- a/src/server/utils/cnn.js
+++ b/src/server/utils/cnn.js
@@ -73,8 +73,7 @@ export const removeDescriptors = transcript => transcript
  * @return {String}            The modified transcript with line breaks inserted.
  */
 export const addBreaksOnSpeakerChange = transcript => transcript
-  .replace(/([".?!\-)\]]+)\s*([.,A-Z\s"()]*:)/g, '$1\n$2')
-
+  .replace(/([".?!)\]-]+)\s*([.,A-Z\s"()-]*:)/g, '$1\n$2')
 
 /**
  * Converts a transcript into a bunch of smaller pieces which can later be
@@ -192,6 +191,8 @@ export const cleanSpeakerName = name => name
   .replace('SENATOR ', '')
   .replace('REPRESENTATIVE ', '')
   .replace('SEN. ', '')
+  .replace(/\s*\([^()]*\)/g, '')
+  .trim()
 
 /**
  * Cleans all speaker names in a list of statements

--- a/src/server/utils/cnn.js
+++ b/src/server/utils/cnn.js
@@ -73,7 +73,7 @@ export const removeDescriptors = transcript => transcript
  * @return {String}            The modified transcript with line breaks inserted.
  */
 export const addBreaksOnSpeakerChange = transcript => transcript
-  .replace(/([".?!)\]-]+)\s*([.,A-Z\s"()-]*:)/g, '$1\n$2')
+  .replace(/([".?!)\]-]+)\s*([.,A-Z\s"'()-]*:)/g, '$1\n$2')
 
 /**
  * Converts a transcript into a bunch of smaller pieces which can later be


### PR DESCRIPTION
Parentheticals in affiliation names were not being removed, and furthermore hyphens in affiliations generally were causing chunks to be improperly split.  This corrects both of those problems.

Ultimately we need to DRY out the regular expressions as described in issue #64.  I have a feeling that edge cases aren't being fully corrected as we expand what an affiliation can look like.

Resolves #135