### PR TITLE
Remove "through translator" descriptors

### DIFF
--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -133,6 +133,10 @@ describe('utils/cnn', () => {
       expect(removeDescriptors('BEES (on camera): WE WILL KILL ALL HUMANS!'))
         .toBe('BEES: WE WILL KILL ALL HUMANS!')
     })
+    it('Should remove through translator', () => {
+      expect(removeDescriptors('HUMAN (through translator): BZZZZzzzzzzzzzzzzzzzz'))
+        .toBe('HUMAN: BZZZZzzzzzzzzzzzzzzzz')
+    })
     it('Should not remove normal parantheticals', () => {
       expect(removeDescriptors('I am sure it will all be fine (aside from all the problems of course.)'))
         .toBe('I am sure it will all be fine (aside from all the problems of course.)')

--- a/src/server/utils/cnn.js
+++ b/src/server/utils/cnn.js
@@ -64,6 +64,7 @@ export const removeDescriptors = transcript => transcript
   .replace(/\s?\(voice[\s-]*over\)/g, '')
   .replace(/\s?\(via telephone\)/g, '')
   .replace(/\s?\(on[\s-]camera\)/g, '')
+  .replace(/\s?\(through[\s-]translator\)/g, '')
   .trim()
 
 /**


### PR DESCRIPTION
This removes `(through translator)` descriptors.  We really need a more generic RegEx to kick these out.

Resolves #141