### PR TITLE
Allow envs to set a global mailing list override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,8 @@ MAILGUN_API_KEY=ABC123
 # The amount of detail you want to appear in logs
 # We use the default npm log levels as described in https://github.com/winstonjs/winston#logging-levels
 LOG_LEVEL=info
+
+# To force all newsletters to send to a specific mailing list (e.g., if we want to run a production
+# environment but have all newsletters sent to testers only), uncomment this and set it to the
+# desired `MAILING_LISTS` key, e.g. `TESTERS`.
+# MAILING_LIST_OVERRIDE=

--- a/src/server/newsletters/AbstractNewsletter.js
+++ b/src/server/newsletters/AbstractNewsletter.js
@@ -1,11 +1,8 @@
 import config from '../config'
+import { getFileContents } from '../utils'
 import {
-  isProductionEnv,
-  getFileContents,
-} from '../utils'
-import {
-  isInternalMailingList,
   getMailingListAddress,
+  guardMailingList,
 } from '../utils/newsletters'
 import {
   getHandlebarsTemplate,
@@ -14,7 +11,6 @@ import {
 } from '../utils/templates'
 import Mailer from '../workers/mailer'
 import logger from '../utils/logger'
-import { MAILING_LISTS } from './constants'
 
 class AbstractNewsletter {
   constructor() {
@@ -155,9 +151,7 @@ class AbstractNewsletter {
    */
   getRecipient = () => {
     const configuredMailingList = config.MAILING_LIST_OVERRIDE || this.getMailingList()
-    const guardedMailingList = (isProductionEnv() || isInternalMailingList(configuredMailingList))
-      ? configuredMailingList
-      : MAILING_LISTS.DEVELOPERS
+    const guardedMailingList = guardMailingList(configuredMailingList)
     return getMailingListAddress(guardedMailingList)
   }
 

--- a/src/server/newsletters/AbstractNewsletter.js
+++ b/src/server/newsletters/AbstractNewsletter.js
@@ -1,9 +1,11 @@
+import config from '../config'
 import {
   isProductionEnv,
   getFileContents,
 } from '../utils'
 import {
   isInternalMailingList,
+  getMailingListAddress,
 } from '../utils/newsletters'
 import {
   getHandlebarsTemplate,
@@ -12,7 +14,7 @@ import {
 } from '../utils/templates'
 import Mailer from '../workers/mailer'
 import logger from '../utils/logger'
-import { MAILING_LIST_ADDRESSES, MAILING_LISTS } from './constants'
+import { MAILING_LISTS } from './constants'
 
 class AbstractNewsletter {
   constructor() {
@@ -138,32 +140,25 @@ class AbstractNewsletter {
   }
 
   /**
-   * Provides the email address for the mailing list associated with the newsletter.
-   * Throws an error if there is none, because that makes the newsletter undeliverable
-   * and means we've either configured it incorrectly or setup our addresses incorrectly.
+   * Provides the recipient mailing list address for the newsletter.
    *
-   * @return {String} The email address for the associated mailing list
-   */
-  getMailingListAddress = () => {
-    const mailingList = this.getMailingList()
-    const mailingListAddress = MAILING_LIST_ADDRESSES[mailingList]
-    if (!mailingListAddress) throw new Error(`There is no email address associated with the mailing list ${mailingList}.`)
-    return mailingListAddress
-  }
-
-  /**
-   * Provides the recipient mailing list address for the newsletter. To make sure we don't send
-   * newsletters to real mailing lists during development, this returns the developer mailing list
-   * if we're not in production mode or trying to send to one of our other interal mailing lists,
-   * like testers.
+   * There are two additions to allow us to test and develop newsletters without mistakenly sending
+   * to real (i.e., production) recipient lists:
+   * 1. If there is a valid MAILING_LIST_OVERRIDE environment variable, use that. We use this almost
+   *    exclusively to test sending newsletters in otherwise production environments.
+   * 2. If we're not running in production, the mailing list must be internal, or else it defaults
+   *    to the devs list.
+   * Note that if a non-production environment has MAILING_LIST_OVERRIDE set to an external mailing
+   * list, it will get hammered into sending to the devs list.
    *
-   * @return {String} The intended newsletter recipient, or the developers mailing list
+   * @return {String} The intended newsletter recipient
    */
   getRecipient = () => {
-    const mailingList = this.getMailingList()
-    return (isProductionEnv() || isInternalMailingList(mailingList))
-      ? this.getMailingListAddress()
-      : MAILING_LIST_ADDRESSES[MAILING_LISTS.DEVELOPERS]
+    const configuredMailingList = config.MAILING_LIST_OVERRIDE || this.getMailingList()
+    const guardedMailingList = (isProductionEnv() || isInternalMailingList(configuredMailingList))
+      ? configuredMailingList
+      : MAILING_LISTS.DEVELOPERS
+    return getMailingListAddress(guardedMailingList)
   }
 
   /**

--- a/src/server/newsletters/constants.js
+++ b/src/server/newsletters/constants.js
@@ -10,6 +10,9 @@ export const INTERNAL_MAILING_LISTS = {
   TESTERS: 'TESTERS',
 }
 
+// This is the list that we will default to for safety under certain conditions
+export const GUARDED_MAILING_LIST = 'DEVELOPERS'
+
 export const MAILING_LIST_ADDRESSES = {
   DEVELOPERS: 'dev@alerts.factstream.co',
   TESTERS: 'test@alerts.factstream.co',

--- a/src/server/utils/__test__/newsletters.test.js
+++ b/src/server/utils/__test__/newsletters.test.js
@@ -2,13 +2,22 @@ import { hasKey } from '..'
 import {
   isInternalMailingList,
   getMailingListAddress,
+  guardMailingList,
 } from '../newsletters'
 import {
+  GUARDED_MAILING_LIST,
   MAILING_LISTS,
   INTERNAL_MAILING_LISTS,
 } from '../../newsletters/constants'
 
 const getInternalMailingList = () => Object.keys(INTERNAL_MAILING_LISTS)[0]
+
+/**
+ * This essentially exists because the guarded list is on the internal mailing list array, so we
+ * can't accurately test guardMailingList() without choosing a different one.
+ */
+const getUnguardedInternalMailingList = () => Object.keys(MAILING_LISTS)
+  .find(list => list !== GUARDED_MAILING_LIST)
 
 const getExternalMailingList = () => Object.keys(MAILING_LISTS)
   .find(list => !hasKey(INTERNAL_MAILING_LISTS, list))
@@ -34,5 +43,18 @@ describe('utils/newsletters', () => {
         getMailingListAddress('FAKE')
       }).toThrowError()
     })
+  })
+  describe('#guardMailingList', () => {
+    it('Should allow internal lists to pass through unguarded', () => {
+      const unguardedInternalMailingList = getUnguardedInternalMailingList()
+      expect(guardMailingList(unguardedInternalMailingList)).toEqual(unguardedInternalMailingList)
+    })
+    it('Should return the guarded list when passed an external list, here in testing', () => {
+      expect(guardMailingList(getExternalMailingList)).toEqual(GUARDED_MAILING_LIST)
+    })
+    /**
+     * TODO: It would be nice to be able to simulate the behavior when `isProductionEnv()` was true.
+     * Possible solution: https://stackoverflow.com/a/48042799
+     */
   })
 })

--- a/src/server/utils/__test__/newsletters.test.js
+++ b/src/server/utils/__test__/newsletters.test.js
@@ -1,6 +1,7 @@
 import { hasKey } from '..'
 import {
   isInternalMailingList,
+  getMailingListAddress,
 } from '../newsletters'
 import {
   MAILING_LISTS,
@@ -13,14 +14,25 @@ const getExternalMailingList = () => Object.keys(MAILING_LISTS)
   .find(list => !hasKey(INTERNAL_MAILING_LISTS, list))
 
 describe('utils/newsletters', () => {
+  const internalMailingList = getInternalMailingList()
+  const externalMailingList = getExternalMailingList()
   describe('#isInternalMailingList', () => {
-    const internalMailingList = getInternalMailingList()
-    const externalMailingList = getExternalMailingList()
     it('Should recognize internal mailing lists', () => {
       expect(isInternalMailingList(internalMailingList)).toBe(true)
     })
     it('Should reject external mailing lists', () => {
       expect(isInternalMailingList(externalMailingList)).toBe(false)
+    })
+  })
+  describe('#getMailingListAddress', () => {
+    it('Should return email addressess for valid mailing lists', () => {
+      expect(getMailingListAddress(internalMailingList)).toContain('@')
+      expect(getMailingListAddress(externalMailingList)).toContain('@')
+    })
+    it('Should throw an error when passed an invalid mailing list', () => {
+      expect(() => {
+        getMailingListAddress('FAKE')
+      }).toThrowError()
     })
   })
 })

--- a/src/server/utils/newsletters.js
+++ b/src/server/utils/newsletters.js
@@ -1,8 +1,12 @@
 import {
+  GUARDED_MAILING_LIST,
   MAILING_LIST_ADDRESSES,
   INTERNAL_MAILING_LISTS,
 } from '../newsletters/constants'
-import { hasKey } from '.'
+import {
+  isProductionEnv,
+  hasKey,
+} from '.'
 
 export const isInternalMailingList = list => hasKey(INTERNAL_MAILING_LISTS, list)
 
@@ -18,3 +22,21 @@ export const getMailingListAddress = (list) => {
   if (!mailingListAddress) throw new Error(`There is no email address associated with the mailing list ${list}.`)
   return mailingListAddress
 }
+
+/**
+ * Protects us from accidentally sending newsletters to production recipients.
+ *
+ * We configure newsletters with an associated mailing list. However, in development/testing, we
+ * want to send these newsletters only to internal mailing lists. Rather than have to reconfigure
+ * newsletters constantly while testing, we simply pass the configured mailing list through this
+ * guard function when determining the recipient. If we're in production mode, or if the newsletter
+ * is configured to send to an internal list anyway, we allow the configured mailing list to
+ * determine the recipeint. Otherwise, we default to the GUARDED_MAILING_LIST constant (currently
+ * the developers list).
+ *
+ * @param  {String} list The mailing list we want to guard
+ * @return {String}      The mailing list we passed in, or the default guarded one
+ */
+export const guardMailingList = list => ((isProductionEnv() || isInternalMailingList(list))
+  ? list
+  : GUARDED_MAILING_LIST)

--- a/src/server/utils/newsletters.js
+++ b/src/server/utils/newsletters.js
@@ -1,7 +1,20 @@
-// Disabling because we intend to have more exports in the future.
-/* eslint-disable import/prefer-default-export */
-
-import { INTERNAL_MAILING_LISTS } from '../newsletters/constants'
+import {
+  MAILING_LIST_ADDRESSES,
+  INTERNAL_MAILING_LISTS,
+} from '../newsletters/constants'
 import { hasKey } from '.'
 
 export const isInternalMailingList = list => hasKey(INTERNAL_MAILING_LISTS, list)
+
+/**
+ * Provides the email address for the mailing list associated with the newsletter.
+ * Throws an error if there is none, because that makes the newsletter undeliverable
+ * and means we've either configured it incorrectly or setup our addresses incorrectly.
+ *
+ * @return {String} The email address for the associated mailing list
+ */
+export const getMailingListAddress = (list) => {
+  const mailingListAddress = MAILING_LIST_ADDRESSES[list]
+  if (!mailingListAddress) throw new Error(`There is no email address associated with the mailing list ${list}.`)
+  return mailingListAddress
+}


### PR DESCRIPTION
We gain a new .env example (`MAILING_LIST_OVERRIDE `) that, when configured, replaces the newsletter-specific mailing list configuration. This mostly exists to let us setup otherwise-production environments that are globally configured to send only to internal mailing lists until otherwise let off the leash to send to their true configured mailing lists.

NB: This still has the old guards that won’t let us accidentally configure local development environments to send to the real lists. (Or, it shouldn’t. I’m scared to test.) If you ever want to do that, you will have to manually get in there and remove the guards and may God have mercy on your soul.

This also moves the function that composes mailing list email addresses off of `AbstractNewsletter` and to a utility function where it belongs, plus tests.

Resolves #138