### PR TITLE
Increase newsletter claim limit to 15

### DIFF
--- a/src/server/newsletters/NationalNewsletter.js
+++ b/src/server/newsletters/NationalNewsletter.js
@@ -12,7 +12,7 @@ import {
 const { Claim } = models
 
 class NationalNewsletter extends AbstractNewsletter {
-  getMailingList = () => MAILING_LISTS.PRIMARY
+  getMailingList = () => MAILING_LISTS.NATIONAL
 
   getPathToTemplate = () => `${__dirname}/templates/national.hbs`
 

--- a/src/server/newsletters/NationalNewsletter.js
+++ b/src/server/newsletters/NationalNewsletter.js
@@ -4,7 +4,10 @@ import assert from 'assert'
 
 import models from '../models'
 import AbstractNewsletter from './AbstractNewsletter'
-import { MAILING_LISTS } from './constants'
+import {
+  NEWSLETTER_SETTINGS,
+  MAILING_LISTS,
+} from './constants'
 
 const { Claim } = models
 
@@ -23,7 +26,7 @@ class NationalNewsletter extends AbstractNewsletter {
   }
 
   fetchTVClaims = () => (Claim.findAll({
-    limit: 15,
+    limit: NEWSLETTER_SETTINGS.DEFAULT.CLAIM_LIMIT,
     where: {
       createdAt: {
         [Sequelize.Op.gte]: dayjs().subtract(1, 'day').format(),

--- a/src/server/newsletters/NationalNewsletter.js
+++ b/src/server/newsletters/NationalNewsletter.js
@@ -23,7 +23,7 @@ class NationalNewsletter extends AbstractNewsletter {
   }
 
   fetchTVClaims = () => (Claim.findAll({
-    limit: 10,
+    limit: 15,
     where: {
       createdAt: {
         [Sequelize.Op.gte]: dayjs().subtract(1, 'day').format(),

--- a/src/server/newsletters/constants.js
+++ b/src/server/newsletters/constants.js
@@ -16,3 +16,9 @@ export const MAILING_LIST_ADDRESSES = {
   PRIMARY: 'alerts@alerts.factstream.co',
   NORTH_CAROLINA: 'northcarolina@alerts.factstream.co',
 }
+
+export const NEWSLETTER_SETTINGS = {
+  DEFAULT: {
+    CLAIM_LIMIT: 15,
+  },
+}

--- a/src/server/newsletters/constants.js
+++ b/src/server/newsletters/constants.js
@@ -1,7 +1,7 @@
 export const MAILING_LISTS = {
   DEVELOPERS: 'DEVELOPERS',
   TESTERS: 'TESTERS',
-  PRIMARY: 'PRIMARY',
+  NATIONAL: 'NATIONAL',
   NORTH_CAROLINA: 'NORTH_CAROLINA',
 }
 
@@ -13,7 +13,7 @@ export const INTERNAL_MAILING_LISTS = {
 export const MAILING_LIST_ADDRESSES = {
   DEVELOPERS: 'dev@alerts.factstream.co',
   TESTERS: 'test@alerts.factstream.co',
-  PRIMARY: 'alerts@alerts.factstream.co',
+  NATIONAL: 'alerts@alerts.factstream.co',
   NORTH_CAROLINA: 'northcarolina@alerts.factstream.co',
 }
 


### PR DESCRIPTION
The old value of 10 was a shot in the dark on my part. Changing to 15 to match current newsletter.

BTW I'm pretty sure this will soon be a constant, but I'm only planning to do that if 15 is our common limit (i.e. once we add other claim types / newsletters), not just to get limit literals out of the class definition.

Resolves #133