### PR TITLE
Add timezone support to scheduler

### DIFF
--- a/src/server/queues/AbstractJobScheduler.js
+++ b/src/server/queues/AbstractJobScheduler.js
@@ -1,3 +1,4 @@
+import { QUEUE_SCHEDULER_TIMEZONE } from './constants'
 
 class AbstractJobScheduler {
   /**
@@ -36,6 +37,7 @@ class AbstractJobScheduler {
 
   getRepeatOptions = () => ({
     cron: this.getScheduleCron(),
+    tz: QUEUE_SCHEDULER_TIMEZONE,
   })
 
   scheduleJobs = () => this.getQueue().add(

--- a/src/server/queues/constants.js
+++ b/src/server/queues/constants.js
@@ -1,9 +1,13 @@
+// The timezone that will govern `Schedules` cron schedules
+export const QUEUE_SCHEDULER_TIMEZONE = 'America/New_York'
+
+// Times are relative to the `QUEUE_SCHEDULER_TIMEZONE`
 export const Schedules = {
   NONE: 'none',
   EVERY_MINUTE: '* * * * *',
   EVERY_HOUR: '0 * * * *',
   EVERY_DAY: '0 0 * * *',
-  EVERY_MORNING: '0 9 * * *',
+  EVERY_MORNING: '0 8 * * *',
 }
 
 export const QueueNames = {


### PR DESCRIPTION
Our scheduler uses cron-style schedule strings. By default, these follow the system clock on whatever machine is executing the queue. This is a problem when you want something to happen at some universal time no matter what machine it’s run on. The obvious answer is “just express it in UTC”, but _that’s_ a problem if we’re very US-centric and want the schedule to remain fixed at a clock time regardless of daylight savings changes, such that “8am Eastern” means 8am in summer and winter.

Turns out our scheduler, Bull, supports specifying which timezone your configuration is in, and then translates that to the host system clock appropriately.

We’re setting our schedule to be relative to New York City, since it’s the greatest city in the world, greatest city in the world (work, work).

While I’m at it, I went ahead and set the `EVERY_MORNING` schedule to the time we want (8am).

Resolves #153
Resolves #154
