### PR TITLE
Fix reference to null schedule

### DIFF
--- a/src/server/queues/claimBusterClaimDetectorQueue/ClaimBusterClaimDetectorJobScheduler.js
+++ b/src/server/queues/claimBusterClaimDetectorQueue/ClaimBusterClaimDetectorJobScheduler.js
@@ -5,7 +5,7 @@ import { Schedules } from '../constants'
 const getQueueFactory = () => new ClaimBusterClaimDetectorQueueFactory()
 
 class ClaimBusterClaimDetectorJobScheduler extends AbstractJobScheduler {
-  getScheduleCron = () => Schedules.None
+  getScheduleCron = () => Schedules.NONE
 
   getQueue = () => getQueueFactory().getQueue()
 }

--- a/src/server/queues/cnnTranscriptListCrawlerQueue/CnnTranscriptListCrawlerJobScheduler.js
+++ b/src/server/queues/cnnTranscriptListCrawlerQueue/CnnTranscriptListCrawlerJobScheduler.js
@@ -5,7 +5,7 @@ import { Schedules } from '../constants'
 const getQueueFactory = () => new CnnTranscriptListCrawlerQueueFactory()
 
 class CnnTranscriptListCrawlerJobScheduler extends AbstractJobScheduler {
-  getScheduleCron = () => Schedules.None
+  getScheduleCron = () => Schedules.NONE
 
   getQueue = () => getQueueFactory().getQueue()
 }

--- a/src/server/queues/cnnTranscriptStatementScraperQueue/CnnTranscriptStatementScraperJobScheduler.js
+++ b/src/server/queues/cnnTranscriptStatementScraperQueue/CnnTranscriptStatementScraperJobScheduler.js
@@ -5,7 +5,7 @@ import { Schedules } from '../constants'
 const getQueueFactory = () => new CnnTranscriptStatementScraperQueueFactory()
 
 class CnnTranscriptStatementScraperJobScheduler extends AbstractJobScheduler {
-  getScheduleCron = () => Schedules.None
+  getScheduleCron = () => Schedules.NONE
 
   getQueue = () => getQueueFactory().getQueue()
 }


### PR DESCRIPTION
The actual `Schedules` property for “no schedule” is `NONE`, but we were referencing it as `None`, causing an `undefined` to be passed to the cron-parser that Bull uses. Besides being wrong, this was throwing an error (that we aren’t catching, whoops) that tripped up scheduling.

Even after making this change, I’m still seeing two other `undefined`s passed to cron-parser, so there’s still more work to be done here.

Affects #150