### PR TITLE
Disable HelloWorldCrawler schedule

### DIFF
--- a/src/server/queues/helloWorldCrawlerQueue/HelloWorldCrawlerJobScheduler.js
+++ b/src/server/queues/helloWorldCrawlerQueue/HelloWorldCrawlerJobScheduler.js
@@ -5,7 +5,7 @@ import { Schedules } from '../constants'
 const getQueueFactory = () => new HelloWorldCrawlerQueueFactory()
 
 class HelloWorldCrawlerJobScheduler extends AbstractJobScheduler {
-  getScheduleCron = () => Schedules.EVERY_MINUTE
+  getScheduleCron = () => Schedules.NONE
 
   getQueue = () => getQueueFactory().getQueue()
 }


### PR DESCRIPTION
The `HelloWorldCrawler` was still scheduled to run every minute, even though it was just a proof of concept. Disabling that so we aren’t unnecessarily crawling google.com and extracting URLs.

Resolves #159