### PR TITLE
Split getQueue into two methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "queue:jobs:list": "babel-node -- src/scripts/listScheduledJobs",
     "queue:jobs:schedule": "babel-node -- src/scripts/scheduleJobs",
     "queue:jobs:unschedule": "babel-node -- src/scripts/unscheduleJobs",
-    "queue:jobs:run:cnn-portal-crawler": "babel-node -- src/scripts/runCrawler",
+    "queue:jobs:run:cnn-portal-crawler": "babel-node -- src/scripts/runCnnCrawler",
     "mailer:send-test": "babel-node -- src/scripts/sendTestEmail",
     "newsletter:send-test": "babel-node -- src/scripts/sendTestNewsletter",
     "sandbox": "babel-node -- src/scripts/_sandbox",

--- a/src/scripts/runCnnCrawler.js
+++ b/src/scripts/runCnnCrawler.js
@@ -1,0 +1,24 @@
+import cnnTranscriptPortalCrawlerQueueDict from '../server/queues/cnnTranscriptPortalCrawlerQueue'
+import cnnTranscriptListCrawlerQueueDict from '../server/queues/cnnTranscriptListCrawlerQueue'
+import cnnTranscriptTranscriptStatementScraperQueueDict from '../server/queues/cnnTranscriptStatementScraperQueue'
+import claimBusterClaimDetectorQueueDict from '../server/queues/claimBusterClaimDetectorQueue'
+
+import {
+  getQueueFromQueueDict,
+  startQueueProcessors,
+} from '../server/utils/queue'
+import logger from '../server/utils/logger'
+
+const cnnTranscriptPortalCrawlerQueue = getQueueFromQueueDict(
+  cnnTranscriptPortalCrawlerQueueDict,
+)
+cnnTranscriptPortalCrawlerQueue.add()
+
+startQueueProcessors([
+  cnnTranscriptPortalCrawlerQueueDict,
+  cnnTranscriptListCrawlerQueueDict,
+  cnnTranscriptTranscriptStatementScraperQueueDict,
+  claimBusterClaimDetectorQueueDict,
+])
+
+logger.info('The crawler is running; you will have to manually exit this process.')

--- a/src/scripts/runCrawler.js
+++ b/src/scripts/runCrawler.js
@@ -1,7 +1,0 @@
-import cnnTranscriptPortalCrawlerQueueDict from '../server/queues/cnnTranscriptPortalCrawlerQueue'
-import { getQueueFromQueueDict } from '../server/utils/queue'
-import logger from '../server/utils/logger'
-
-const cnnTranscriptPortalCrawlerQueue = getQueueFromQueueDict(cnnTranscriptPortalCrawlerQueueDict)
-cnnTranscriptPortalCrawlerQueue.add()
-logger.info('The crawler is running; you will have to manually exit this process.')

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,6 +1,11 @@
 import queueDicts from './queues'
-import { getQueueFromQueueDict } from './utils/queue'
+import {
+  startQueueProcessors,
+  getQueueFromQueueDict,
+} from './utils/queue'
 import logger from './utils/logger'
+
+startQueueProcessors(queueDicts)
 
 queueDicts.forEach(async (queueDict) => {
   const queue = getQueueFromQueueDict(queueDict)

--- a/src/server/queues/AbstractJobScheduler.js
+++ b/src/server/queues/AbstractJobScheduler.js
@@ -14,16 +14,22 @@ class AbstractJobScheduler {
   }
 
   /**
-   * Abstract method that provides the queue object that the schedule
+   * Abstract method that provides the queue factory for the queue that the schedule
    * should be applied to.
    *
    * OVERRIDE WHEN EXTENDING
    *
-   * @return {Queue} the queue object
+   * @return {AbstractQueueFactory} The instantiated queue factory
    */
-  getQueue = () => {
-    throw new Error('You extended AbstractJobScheduler but forgot to define getQueue()')
+  getQueueFactory = () => {
+    throw new Error('You extended AbstractJobScheduler but forgot to define getQueueFactory()')
   }
+
+  /**
+   * Invokes getQueueFactory to actually get the insertion queue
+   * @return {Queue} The queue to schedule against
+   */
+  getQueue = () => this.getQueueFactory().getQueue()
 
   /**
    * Method that provides the job information that should be part of the scheduled

--- a/src/server/queues/AbstractQueueFactory.js
+++ b/src/server/queues/AbstractQueueFactory.js
@@ -37,8 +37,13 @@ class AbstractQueueFactory {
     )
     queue.on('error', error => logger.error(error))
     queue.on('failed', (job, error) => logger.warn(error))
-    queue.process(this.getPathToProcessor())
     return queue
+  }
+
+  startQueueProcessor = () => {
+    logger.debug(`Starting queue processor: ${this.getQueueName()}`)
+    const queue = this.getQueue()
+    queue.process(this.getPathToProcessor())
   }
 }
 

--- a/src/server/queues/claimBusterClaimDetectorQueue/ClaimBusterClaimDetectorJobScheduler.js
+++ b/src/server/queues/claimBusterClaimDetectorQueue/ClaimBusterClaimDetectorJobScheduler.js
@@ -2,12 +2,10 @@ import ClaimBusterClaimDetectorQueueFactory from './ClaimBusterClaimDetectorQueu
 import AbstractJobScheduler from '../AbstractJobScheduler'
 import { Schedules } from '../constants'
 
-const getQueueFactory = () => new ClaimBusterClaimDetectorQueueFactory()
-
 class ClaimBusterClaimDetectorJobScheduler extends AbstractJobScheduler {
   getScheduleCron = () => Schedules.NONE
 
-  getQueue = () => getQueueFactory().getQueue()
+  getQueueFactory = () => new ClaimBusterClaimDetectorQueueFactory()
 }
 
 export default ClaimBusterClaimDetectorJobScheduler

--- a/src/server/queues/cnnTranscriptListCrawlerQueue/CnnTranscriptListCrawlerJobScheduler.js
+++ b/src/server/queues/cnnTranscriptListCrawlerQueue/CnnTranscriptListCrawlerJobScheduler.js
@@ -2,12 +2,10 @@ import CnnTranscriptListCrawlerQueueFactory from './CnnTranscriptListCrawlerQueu
 import AbstractJobScheduler from '../AbstractJobScheduler'
 import { Schedules } from '../constants'
 
-const getQueueFactory = () => new CnnTranscriptListCrawlerQueueFactory()
-
 class CnnTranscriptListCrawlerJobScheduler extends AbstractJobScheduler {
   getScheduleCron = () => Schedules.NONE
 
-  getQueue = () => getQueueFactory().getQueue()
+  getQueueFactory = () => new CnnTranscriptListCrawlerQueueFactory()
 }
 
 export default CnnTranscriptListCrawlerJobScheduler

--- a/src/server/queues/cnnTranscriptListCrawlerQueue/cnnTranscriptListCrawlerJobProcessor.js
+++ b/src/server/queues/cnnTranscriptListCrawlerQueue/cnnTranscriptListCrawlerJobProcessor.js
@@ -4,8 +4,9 @@ import CnnTranscriptStatementScraper from '../../workers/scrapers/CnnTranscriptS
 import cnnTranscriptStatementScraperQueueDict from '../cnnTranscriptStatementScraperQueue'
 import { isDateBeyondScrapeHorizon } from '../../utils/scraper'
 import { extractPublicationDateFromTranscriptUrl } from '../../utils/cnn'
+import { getQueueFromQueueDict } from '../../utils/queue'
 
-const statementScraperQueue = cnnTranscriptStatementScraperQueueDict.factory.getQueue()
+const statementScraperQueue = getQueueFromQueueDict(cnnTranscriptStatementScraperQueueDict)
 
 const scrapeTranscriptUrl = url => statementScraperQueue.add({ url })
 

--- a/src/server/queues/cnnTranscriptPortalCrawlerQueue/CnnTranscriptPortalCrawlerJobScheduler.js
+++ b/src/server/queues/cnnTranscriptPortalCrawlerQueue/CnnTranscriptPortalCrawlerJobScheduler.js
@@ -2,12 +2,10 @@ import CnnTranscriptPortalCrawlerQueueFactory from './CnnTranscriptPortalCrawler
 import AbstractJobScheduler from '../AbstractJobScheduler'
 import { Schedules } from '../constants'
 
-const getQueueFactory = () => new CnnTranscriptPortalCrawlerQueueFactory()
-
 class CnnTranscriptPortalCrawlerJobScheduler extends AbstractJobScheduler {
   getScheduleCron = () => Schedules.EVERY_MINUTE
 
-  getQueue = () => getQueueFactory().getQueue()
+  getQueueFactory = () => new CnnTranscriptPortalCrawlerQueueFactory()
 }
 
 export default CnnTranscriptPortalCrawlerJobScheduler

--- a/src/server/queues/cnnTranscriptPortalCrawlerQueue/cnnTranscriptPortalCrawlerJobProcessor.js
+++ b/src/server/queues/cnnTranscriptPortalCrawlerQueue/cnnTranscriptPortalCrawlerJobProcessor.js
@@ -1,7 +1,8 @@
 import { CnnTranscriptPortalCrawler } from '../../workers/crawlers/CnnCrawlers'
 import cnnTranscriptListCrawlerQueueDict from '../cnnTranscriptListCrawlerQueue'
+import { getQueueFromQueueDict } from '../../utils/queue'
 
-const listCrawlerQueue = cnnTranscriptListCrawlerQueueDict.factory.getQueue()
+const listCrawlerQueue = getQueueFromQueueDict(cnnTranscriptListCrawlerQueueDict)
 
 const crawlTranscriptListUrl = url => listCrawlerQueue.add({ url })
 

--- a/src/server/queues/cnnTranscriptStatementScraperQueue/CnnTranscriptStatementScraperJobScheduler.js
+++ b/src/server/queues/cnnTranscriptStatementScraperQueue/CnnTranscriptStatementScraperJobScheduler.js
@@ -2,12 +2,10 @@ import CnnTranscriptStatementScraperQueueFactory from './CnnTranscriptStatementS
 import AbstractJobScheduler from '../AbstractJobScheduler'
 import { Schedules } from '../constants'
 
-const getQueueFactory = () => new CnnTranscriptStatementScraperQueueFactory()
-
 class CnnTranscriptStatementScraperJobScheduler extends AbstractJobScheduler {
   getScheduleCron = () => Schedules.NONE
 
-  getQueue = () => getQueueFactory().getQueue()
+  getQueueFactory = () => new CnnTranscriptStatementScraperQueueFactory()
 }
 
 export default CnnTranscriptStatementScraperJobScheduler

--- a/src/server/queues/cnnTranscriptStatementScraperQueue/cnnTranscriptStatementScraperJobProcessor.js
+++ b/src/server/queues/cnnTranscriptStatementScraperQueue/cnnTranscriptStatementScraperJobProcessor.js
@@ -1,7 +1,10 @@
 import CnnTranscriptStatementScraper from '../../workers/scrapers/CnnTranscriptStatementScraper'
 import claimBusterClaimDetectorQueueDict from '../claimBusterClaimDetectorQueue'
+import { getQueueFromQueueDict } from '../../utils/queue'
 
-const claimBusterClaimDetectorQueue = claimBusterClaimDetectorQueueDict.factory.getQueue()
+const claimBusterClaimDetectorQueue = getQueueFromQueueDict(
+  claimBusterClaimDetectorQueueDict,
+)
 
 const detectClaims = statement => claimBusterClaimDetectorQueue.add({ statement })
 

--- a/src/server/queues/helloWorldCrawlerQueue/HelloWorldCrawlerJobScheduler.js
+++ b/src/server/queues/helloWorldCrawlerQueue/HelloWorldCrawlerJobScheduler.js
@@ -2,12 +2,10 @@ import HelloWorldCrawlerQueueFactory from './HelloWorldCrawlerQueueFactory'
 import AbstractJobScheduler from '../AbstractJobScheduler'
 import { Schedules } from '../constants'
 
-const getQueueFactory = () => new HelloWorldCrawlerQueueFactory()
-
 class HelloWorldCrawlerJobScheduler extends AbstractJobScheduler {
   getScheduleCron = () => Schedules.NONE
 
-  getQueue = () => getQueueFactory().getQueue()
+  getQueueFactory = () => new HelloWorldCrawlerQueueFactory()
 }
 
 export default HelloWorldCrawlerJobScheduler

--- a/src/server/queues/nationalNewsletterDeliveryQueue/NationalNewsletterDeliveryJobScheduler.js
+++ b/src/server/queues/nationalNewsletterDeliveryQueue/NationalNewsletterDeliveryJobScheduler.js
@@ -2,12 +2,10 @@ import NationalNewsletterDeliveryQueueFactory from './NationalNewsletterDelivery
 import AbstractJobScheduler from '../AbstractJobScheduler'
 import { Schedules } from '../constants'
 
-const getQueueFactory = () => new NationalNewsletterDeliveryQueueFactory()
-
 class NationalNewsletterDeliveryJobScheduler extends AbstractJobScheduler {
   getScheduleCron = () => Schedules.EVERY_MORNING
 
-  getQueue = () => getQueueFactory().getQueue()
+  getQueueFactory = () => new NationalNewsletterDeliveryQueueFactory()
 }
 
 export default NationalNewsletterDeliveryJobScheduler

--- a/src/server/utils/queue.js
+++ b/src/server/utils/queue.js
@@ -1,3 +1,8 @@
+export const startQueueProcessorFromQueueDict = (queueDict) => {
+  const queueFactory = queueDict.factory
+  return queueFactory.startQueueProcessor()
+}
+
 export const getQueueFromQueueDict = (queueDict) => {
   const queueFactory = queueDict.factory
   return queueFactory.getQueue()
@@ -7,3 +12,6 @@ export const getRepeatableJobsFromQueueDict = async (queueDict) => {
   const queue = getQueueFromQueueDict(queueDict)
   return queue.getRepeatableJobs()
 }
+
+export const startQueueProcessors = queueDicts => queueDicts
+  .forEach(startQueueProcessorFromQueueDict)


### PR DESCRIPTION
I spent a lot of time digging around and documented that outcome in [this potentially relevant bull issue](https://github.com/OptimalBits/bull/issues/923#issuecomment-522665737).

We had misunderstood Bull's concurrency mechanism, and whenever we generated a new queue we would create a queue with the processor attached.  This actually meant that every single time we ran getQueue() we were also creating a new job processor for that queue.

This meant that instead of having one job processor per queue we were having... many more.

This commit creates two types of Queue factory method:

1. getInsertionQueue -- this creates a queue objec t solely for the purpose of inserting new jobs.  Generally speaking this is the method that will be called.

2. getProcessingQueue -- this creates a queue object that is registered to process jobs.  This should never be called from inside a queue processor script and should really only be called once.

This commit also changes the template for QueueScheduler objects -- it didn't make sense for them to each implement an external getQueueFactory method and then invoke it identically to override an internal getQueue.

We now have getQueueFactory as the abstract method and getQueue sitting as an implemented method in the Abstract class.

This is related to #162 though we won't know for sure that it resolves until after deploying.