### PR TITLE
Handle rejected promises in job-scheduling tasks

### DIFF
--- a/src/scripts/listScheduledJobs.js
+++ b/src/scripts/listScheduledJobs.js
@@ -8,7 +8,9 @@ const renderJobList = jobList => jobList.forEach((job) => {
 })
 
 const promises = queueDicts.map(getRepeatableJobsFromQueueDict)
-Promise.all(promises).then((jobLists) => {
-  jobLists.forEach(renderJobList)
-  process.exit()
-})
+Promise.all(promises)
+  .then((jobLists) => {
+    jobLists.forEach(renderJobList)
+  })
+  .catch(error => logger.error(`Could not list all scheduled jobs: ${error}`))
+  .finally(() => process.exit())

--- a/src/scripts/scheduleJobs.js
+++ b/src/scripts/scheduleJobs.js
@@ -8,7 +8,9 @@ const renderResults = (results) => {
 }
 
 const promises = queueDicts.map(scheduleJobs)
-Promise.all(promises).then((results) => {
-  renderResults(results)
-  process.exit()
-})
+Promise.all(promises)
+  .then((results) => {
+    renderResults(results)
+  })
+  .catch(error => logger.error(`Could not schedule all jobs: ${error}`))
+  .finally(() => process.exit())

--- a/src/scripts/unscheduleJobs.js
+++ b/src/scripts/unscheduleJobs.js
@@ -20,7 +20,9 @@ const unscheduleJobs = (queueDict) => {
 }
 
 const promises = queueDicts.map(unscheduleJobs)
-Promise.all(promises).then((results) => {
-  logger.info(`Jobs ${isHardFlagSet() ? '(hard) ' : ''}unscheduled for ${results.length} queues`)
-  process.exit()
-})
+Promise.all(promises)
+  .then((results) => {
+    logger.info(`Jobs ${isHardFlagSet() ? '(hard) ' : ''}unscheduled for ${results.length} queues`)
+  })
+  .catch(error => logger.error(`Could not unschedule all jobs: ${error}`))
+  .finally(() => process.exit())


### PR DESCRIPTION
The job-scheduling tasks run a series of promises. Before this change, we weren’t catching rejected promises, so a problem with any of them (1) wasn’t handled gracefully and (2) never exited the process, since `process.exit()` was called during the first `then()`, which assumes resolution.

Fixed (1) by adding a `catch()` with error-logging and (2) by moving the `process.exit()` to a `finally()` that executes in all cases.

(Note: `Promise#finally()` is still a draft and not supported by IE in-browser, but is supported in Node v10+.)

Resolves #150