### PR TITLE
Slow down CNN transcript crawler to hourly

### DIFF
--- a/src/server/queues/cnnTranscriptPortalCrawlerQueue/CnnTranscriptPortalCrawlerJobScheduler.js
+++ b/src/server/queues/cnnTranscriptPortalCrawlerQueue/CnnTranscriptPortalCrawlerJobScheduler.js
@@ -5,7 +5,7 @@ import { Schedules } from '../constants'
 const getQueueFactory = () => new CnnTranscriptPortalCrawlerQueueFactory()
 
 class CnnTranscriptPortalCrawlerJobScheduler extends AbstractJobScheduler {
-  getScheduleCron = () => Schedules.EVERY_MINUTE
+  getScheduleCron = () => Schedules.EVERY_HOUR
 
   getQueue = () => getQueueFactory().getQueue()
 }


### PR DESCRIPTION
Running the crawler every minute is a bit eager.

Resolves #171