### PR TITLE
Invert media queries to default mobile

### DIFF
--- a/src/server/newsletters/templates/partials/head.hbs
+++ b/src/server/newsletters/templates/partials/head.hbs
@@ -7,19 +7,17 @@
   <style>
     body {
       margin: 0;
-      padding: 0.5em 0.5em 2em;
+      padding: 0.5em;
       font-size: 14px;
       line-height: 1.6;
+      background-color: #fff;
       color: #111;
       font-weight: normal;
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-      background-color: #eee;
     }
     #wrapper {
       max-width: 50em;
       background-color: white;
-      box-shadow: 4px 4px 0 #aaa;
-      padding: 1em;
     }
     .intro {
       margin-top: 0;
@@ -104,7 +102,7 @@
     .claim[data-platform="Facebook"] .claim__content {
       border-color: #3b5998;
     }
-    h1,h2,h3 {
+    h3,h4,h5,h6 {
       text-transform: uppercase;
     }
     b {
@@ -113,12 +111,13 @@
     a:hover {
       text-decoration: none;
     }
-    @media only screen and (max-width: 480px) {
+    @media only screen and (min-width: 480px) {
       body {
-        padding: 0;
+        background-color: #eee !important;
       }
       #wrapper {
-        box-shadow: none;
+        padding: 1em;
+        box-shadow: 4px 4px 0 #aaa;
       }
     }
     {{!-- BEGIN CLIENT-SPECIFIC HACKS --}}


### PR DESCRIPTION
This is discussed more in the attached issue, but essentially not all email clients pay attention to media queries. This was a problem because our mobile styles are more important than our desktop styles, and in the event that one of those scenarios will be ignored, we want the desktop styles ignored.

So this inverts our behavior so that the mobile styles are the defaults, and we apply desktop styles with media queries, rather than the reverse.

Resolves #165