### PR TITLE
Stop scheduling jobs that have a `NONE` schedule

### DIFF
--- a/src/scripts/scheduleJobs.js
+++ b/src/scripts/scheduleJobs.js
@@ -3,8 +3,10 @@ import logger from '../server/utils/logger'
 
 const scheduleJobs = queueDict => queueDict.scheduler.scheduleJobs()
 
+const isJob = job => (!!job && job.constructor.name === 'Job')
+
 const renderScheduledJobs = scheduledJobs => scheduledJobs
-  .filter(job => !!job)
+  .filter(isJob)
   .forEach(job => logger.info(`Scheduled job: ${job.toKey()}`))
 
 const scheduleableQueues = queueDicts.filter(queueDict => queueDict.scheduler.getIsScheduled())

--- a/src/scripts/scheduleJobs.js
+++ b/src/scripts/scheduleJobs.js
@@ -3,14 +3,15 @@ import logger from '../server/utils/logger'
 
 const scheduleJobs = queueDict => queueDict.scheduler.scheduleJobs()
 
-const renderResults = (results) => {
-  results.forEach(result => logger.info(`Scheduled job: ${result.name}`))
-}
+const renderScheduledJobs = scheduledJobs => scheduledJobs
+  .filter(job => !!job)
+  .forEach(job => logger.info(`Scheduled job: ${job.toKey()}`))
 
-const promises = queueDicts.map(scheduleJobs)
+const scheduleableQueues = queueDicts.filter(queueDict => queueDict.scheduler.getIsScheduled())
+const promises = scheduleableQueues.map(scheduleJobs)
 Promise.all(promises)
-  .then((results) => {
-    renderResults(results)
+  .then((jobs) => {
+    renderScheduledJobs(jobs)
   })
   .catch(error => logger.error(`Could not schedule all jobs: ${error}`))
   .finally(() => process.exit())

--- a/src/server/queues/AbstractJobScheduler.js
+++ b/src/server/queues/AbstractJobScheduler.js
@@ -1,4 +1,7 @@
-import { QUEUE_SCHEDULER_TIMEZONE } from './constants'
+import {
+  Schedules,
+  QUEUE_SCHEDULER_TIMEZONE,
+} from './constants'
 
 class AbstractJobScheduler {
   /**
@@ -41,15 +44,18 @@ class AbstractJobScheduler {
    */
   getJobData = () => ({})
 
+  getIsScheduled = () => this.getScheduleCron() !== Schedules.NONE
+
   getRepeatOptions = () => ({
     cron: this.getScheduleCron(),
     tz: QUEUE_SCHEDULER_TIMEZONE,
   })
 
-  scheduleJobs = () => this.getQueue().add(
-    this.getJobData(),
-    { repeat: this.getRepeatOptions() },
-  )
+  scheduleJobs = () => (this.getIsScheduled()
+    ? this.getQueue().add(
+      this.getJobData(),
+      { repeat: this.getRepeatOptions() },
+    ) : null)
 
   unscheduleJobs = () => this.getQueue().removeRepeatable(
     this.getRepeatOptions(),


### PR DESCRIPTION
We have the ability to create a job scheduler that should not actually be scheduled by configuring its schedule as `NONE`. Problem is, we still added a repeatable job to the queue, but with an invalid cron pattern. What we should’ve been doing is not schedule these jobs at all; `NONE` should make them a scheduling no-op.

This commit makes that real (jazz hands). Now the `scheduleJobs()` verifies the schedule isn’t `NONE` before scheduling it, else it returns `null`. (This does mean any code that checks the return value of `scheduleJobs()` should know that it may receive a `Job` object _or_ a `null` value. Thus the [`filter(job => !!job)` guardrail on the `scheduleJobs.js` task](https://github.com/TechAndCheck/tech-and-check-alerts/blob/b19aad2ff2b2cf70d00338a8282591d6e6e232a8/src/scripts/scheduleJobs.js#L7).)

I also modified the `scheduleJobs.js` task to prefilter jobs by those that even can be scheduled, by checking the `getIsScheduled()` method of each. Catch ‘em comin’ and goin’, Papa always said.

Resolves #172