### PR TITLE
Remove `REP.` prefix from speaker name

### DIFF
--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -372,6 +372,8 @@ describe('utils/cnn', () => {
         .toBe('JIMMY DUST')
       expect(cleanSpeakerName('REPRESENTATIVE JIMMY DUST'))
         .toBe('JIMMY DUST')
+      expect(cleanSpeakerName('REP. JIMMY DUST'))
+        .toBe('JIMMY DUST')
     })
     it('Should remove parentheticals', () => {
       expect(cleanSpeakerName('JIMMY DUST (D-MA)'))

--- a/src/server/utils/cnn.js
+++ b/src/server/utils/cnn.js
@@ -216,6 +216,7 @@ export const cleanSpeakerName = name => name
   .replace('SENATOR ', '')
   .replace('REPRESENTATIVE ', '')
   .replace('SEN. ', '')
+  .replace('REP. ', '')
   .replace(/\s*\([^()]*\)/g, '')
   .trim()
 


### PR DESCRIPTION
Straightforward: we strip `REPRESENTATIVE`, `SENATOR`, and `SEN.` but missed `REP.`.

Resolves #178