### PR TITLE
Collapse repeated whitespace to a single space

### DIFF
--- a/src/server/utils/__test__/index.test.js
+++ b/src/server/utils/__test__/index.test.js
@@ -1,5 +1,8 @@
 import {
-  isTestEnv, isDevelopmentEnv, isProductionEnv,
+  isTestEnv,
+  isDevelopmentEnv,
+  isProductionEnv,
+  squish,
 } from '..'
 
 describe('utils/index', () => {
@@ -16,6 +19,11 @@ describe('utils/index', () => {
   describe('#isProductionEnv', () => {
     it('Should report that we are in not in the production environment', () => {
       expect(isProductionEnv()).toBe(false)
+    })
+  })
+  describe('#squish', () => {
+    it('Should replace all whitespace with single spaces', () => {
+      expect(squish('Too  much   space.\nAmiright?')).toBe('Too much space. Amiright?')
     })
   })
 })

--- a/src/server/utils/__test__/scraper.test.js
+++ b/src/server/utils/__test__/scraper.test.js
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs'
 import {
   isDateBeyondScrapeHorizon,
+  squishStatementsText,
 } from '../scraper'
 
 import config from '../../config'
@@ -20,5 +21,19 @@ describe('isDateBeyondScrapeHorizon', () => {
       .toBe(false)
     expect(isDateBeyondScrapeHorizon(withinHorizonDate.format()))
       .toBe(false)
+  })
+})
+
+describe('squishStatementsText', () => {
+  const statements = [
+    { text: 'Hello  world!' },
+    { text: 'Hello   world!' },
+    { text: 'Hello\nworld!' },
+  ]
+  it('Should replace repeated whitespace sequences with single spaces in statement text', () => {
+    const squishedStatements = squishStatementsText(statements)
+    squishedStatements.forEach((statement) => {
+      expect(statement.text).toBe('Hello world!')
+    })
   })
 })

--- a/src/server/utils/index.js
+++ b/src/server/utils/index.js
@@ -19,10 +19,9 @@ export const runPromiseSequence = promiseArray => promiseArray.reduce(
 export const runSequence = (sequence, seed) => sequence.reduce((param, fn) => fn(param), seed)
 
 /**
- * Squish a string by collapsing repeated whitespace to a single space.
+ * Squish a string by replacing all whitespace sequences with a single space.
  *
- * This has the practical effect and primary purpose of reducing multiple spaces to single spaces,
- * but as a side effect it will replace tabs and newlines with a space.
+ * Note that this affects all whitespace, including tabs and newlines.
  *
  * @param  {String} string The string you want to squish
  * @return {String}        The string with all whitespace sequences collapsed to single spaces

--- a/src/server/utils/index.js
+++ b/src/server/utils/index.js
@@ -17,3 +17,14 @@ export const runPromiseSequence = promiseArray => promiseArray.reduce(
 )
 
 export const runSequence = (sequence, seed) => sequence.reduce((param, fn) => fn(param), seed)
+
+/**
+ * Squish a string by collapsing repeated whitespace to a single space.
+ *
+ * This has the practical effect and primary purpose of reducing multiple spaces to single spaces,
+ * but as a side effect it will replace tabs and newlines with a space.
+ *
+ * @param  {String} string The string you want to squish
+ * @return {String}        The string with all whitespace sequences collapsed to single spaces
+ */
+export const squish = string => string.replace(/\s+/g, ' ')

--- a/src/server/utils/scraper.js
+++ b/src/server/utils/scraper.js
@@ -1,7 +1,6 @@
-// Disabling because we intend to have more exports in the future.
-/* eslint-disable import/prefer-default-export */
 import dayjs from 'dayjs'
 import config from '../config'
+import { squish } from '.'
 
 /**
  * Determine if a date is within or beyond the configured horizon (i.e., a number of days ago).
@@ -15,3 +14,14 @@ import config from '../config'
 export const isDateBeyondScrapeHorizon = date => dayjs()
   .subtract(config.SCRAPE_DAY_HORIZON, 'day')
   .isAfter(date)
+
+/**
+ * Squish (collapse repeated whitespace to a single space) statement text.
+ *
+ * @param  {Object[]} statements Array of statement objects
+ * @return {Object[]}            Statements objects with their `text` properties squished
+ */
+export const squishStatementsText = statements => statements.map(statement => ({
+  ...statement,
+  text: squish(statement.text),
+}))

--- a/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
+++ b/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
@@ -3,6 +3,9 @@ import cheerio from 'cheerio'
 import { STATEMENT_SCRAPER_NAMES } from './constants'
 
 import {
+  squishStatementsText,
+} from '../../utils/scraper'
+import {
   isTranscriptUrl,
   getFullCnnUrl,
   removeTimestamps,
@@ -59,6 +62,7 @@ class CnnTranscriptStatementScraper extends AbstractStatementScraper {
       normalizeStatementSpeakers,
       removeNetworkAffiliatedStatements,
       removeUnattributableStatements,
+      squishStatementsText,
       this.addScraperNameToStatements,
       this.addCanonicalUrlToStatements,
     ] // Note that order does matter here


### PR DESCRIPTION
Because of line breaks and formatting, we often end up with claims full of multiple spaces between words. This gets visually collapsed to a single space in most rendering situations (like HTML), but we shouldn’t rely on that, and we should clean these down to single spaces when possible.

This adds a generic `squish()` utility (named after Ruby’s), plus a scraper utility for iterating over statements and squishing their text, plus tests, and then adds that squish utility to the `CnnTranscriptStatementScraper` sequence of statement-cleaning functions.

Resolves #106