### PR TITLE
Canonize CNN URLs as transcripts.cnn.com

### DIFF
--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -56,16 +56,20 @@ describe('utils/cnn', () => {
     it('Should not modify a complete URL', () => {
       expect(getFullCnnUrl('http://google.com'))
         .toBe('http://google.com')
+      expect(getFullCnnUrl('http://transcripts.cnn.com'))
+        .toBe('http://transcripts.cnn.com')
+    })
+    it('Should convert a naked cnn.com URL', () => {
       expect(getFullCnnUrl('http://cnn.com'))
-        .toBe('http://cnn.com')
+        .toBe('http://transcripts.cnn.com')
     })
     it('Should prepend a relative URL', () => {
       expect(getFullCnnUrl('TRANSCRIPTS'))
-        .toBe('http://cnn.com/TRANSCRIPTS')
+        .toBe('http://transcripts.cnn.com/TRANSCRIPTS')
     })
     it('Should prepend a relative URL starting with /', () => {
       expect(getFullCnnUrl('/TRANSCRIPTS'))
-        .toBe('http://cnn.com/TRANSCRIPTS')
+        .toBe('http://transcripts.cnn.com/TRANSCRIPTS')
     })
   })
 

--- a/src/server/utils/cnn.js
+++ b/src/server/utils/cnn.js
@@ -30,9 +30,10 @@ export const isTranscriptUrl = url => url.startsWith('/TRANSCRIPTS/')
   && url.endsWith('.html')
 
 export const getFullCnnUrl = (url) => {
+  if (url.startsWith('/')) return `http://transcripts.cnn.com${url}`
+  if (url.startsWith('http://cnn.com')) return url.replace('//cnn.com', '//transcripts.cnn.com')
   if (url.startsWith('http')) return url
-  if (url.startsWith('/')) return `http://cnn.com${url}`
-  return `http://cnn.com/${url}`
+  return `http://transcripts.cnn.com/${url}`
 }
 
 /**


### PR DESCRIPTION
For some reason, `http://cnn.com/TRANSCRIPTS` URLs perform some server magic that Chrome tolerates but which ties up Firefox and Safari, while the `http://transcripts.cnn.com/TRANSCRIPTS` variant works universally.

Modify our tests and utilities to always prefer the safer one so that Firefox and Safari users can actually use the transcript links in the newsletters.

Resolves #143