### PR TITLE
Add platforms and date to newsletter subject line

### DIFF
--- a/src/server/newsletters/NationalNewsletter.js
+++ b/src/server/newsletters/NationalNewsletter.js
@@ -18,7 +18,11 @@ class NationalNewsletter extends AbstractNewsletter {
 
   getPathToTextTemplate = () => `${__dirname}/templates/nationalText.hbs`
 
-  getSubject = () => 'Tech & Check Alerts'
+  getSubject = () => {
+    const platforms = ['CNN']
+    const date = dayjs().format('MM/DD/YY')
+    return `Tech & Check Alerts: ${platforms.join(', ')} ${date}`
+  }
 
   assertNewsletterIsSendable = async () => {
     const bodyData = await this.getCachedBodyData()


### PR DESCRIPTION
Subscribers like to be able to quickly see the platforms scraped and the day’s date in the subject line of the newsletters.

Resolves #184