### PR TITLE
Add twitter accounts table

### DIFF
--- a/src/server/migrations/20190828142735-create-twitter-accounts.js
+++ b/src/server/migrations/20190828142735-create-twitter-accounts.js
@@ -1,0 +1,28 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('twitter_accounts', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER,
+    },
+    screen_name: {
+      type: Sequelize.STRING(128),
+    },
+    preferred_display_name: {
+      type: Sequelize.STRING(512),
+    },
+    list_name: {
+      type: Sequelize.STRING(128),
+    },
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+  }),
+  down: queryInterface => queryInterface.dropTable('twitter_accounts'),
+}

--- a/src/server/models/TwitterAccount.js
+++ b/src/server/models/TwitterAccount.js
@@ -1,0 +1,8 @@
+module.exports = (sequelize, DataTypes) => {
+  const TwitterAccount = sequelize.define('TwitterAccount', {
+    screenName: DataTypes.STRING(128),
+    preferredDisplayName: DataTypes.STRING(512),
+    listName: DataTypes.STRING(128),
+  }, {})
+  return TwitterAccount
+}


### PR DESCRIPTION
Our twitter scraper is not going to be scraping everything on twitter, so we need a mechanism to specify which accounts are of interest.
 
This commit creates the migration and model for tracking which accounts are which.  The list_name column allows us to have more than one "bucket" that the accounts are in (which will be needed for the short term as we have localized newsletters)

This table will be populated in a separate scrape of the existing google spreadsheets for the two twitter lists; eventually we may want to explore a local administrative interface for that list management.

Related to #26