### PR TITLE
Add Twitter claims to National newsletter

### DIFF
--- a/src/server/constants.js
+++ b/src/server/constants.js
@@ -6,7 +6,12 @@ export const ENV_NAMES = {
 
 export const CLAIMBUSTER_THRESHHOLD = 0.5
 
-// Every property of this object should have a corresponding property on `STATEMENT_SCRAPER_NAMES`
-export const CLAIM_PLATFORM_NAMES = {
-  CNN_TRANSCRIPT: 'CNN',
+export const PLATFORMS = {
+  CNN: 'CNN',
+  TWITTER: 'TWITTER',
+}
+
+export const PLATFORM_NAMES = {
+  CNN: 'CNN',
+  TWITTER: 'Twitter',
 }

--- a/src/server/newsletters/constants.js
+++ b/src/server/newsletters/constants.js
@@ -25,3 +25,8 @@ export const NEWSLETTER_SETTINGS = {
     CLAIM_LIMIT: 15,
   },
 }
+
+export const NEWSLETTER_MEDIA = {
+  TV: 'TV',
+  SOCIAL: 'SOCIAL',
+}

--- a/src/server/newsletters/templates/national.hbs
+++ b/src/server/newsletters/templates/national.hbs
@@ -3,21 +3,47 @@
 
 <div class="claim-section">
   <h1 class="claim-section__header">📺 TV Claims 📺</h1>
-  <ul class="claims">
-  {{#each tvClaims}}
-    <li class="claim" data-platform="{{convertScraperNameToPlatformName scraperName}}">
-      <div class="claim__metadata">
-        <a href="{{canonicalUrl}}" class="claim__permalink">
-          <cite class="claim__speaker">
-            {{speakerName}}
-          </cite>
-          {{#if source}}<span class="claim__source">on {{ source }}</span>{{/if}}
-          <span class="claim__platform">({{convertScraperNameToPlatformName scraperName}})</span></a>:
-      </div>
-      <blockquote class="claim__content">{{content}}</blockquote>
-    </li>
-  {{/each}}
-  </ul>
+  {{#if claims.TV.length}}
+    <ul class="claims">
+    {{#each claims.TV}}
+      <li class="claim" data-platform="{{convertScraperNameToPlatformName scraperName}}">
+        <div class="claim__metadata">
+          <a href="{{canonicalUrl}}" class="claim__permalink">
+            <cite class="claim__speaker">
+              {{speakerName}}
+            </cite>
+            {{#if source}}<span class="claim__source">on {{ source }}</span>{{/if}}
+            <span class="claim__platform">({{convertScraperNameToPlatformName scraperName}})</span></a>:
+        </div>
+        <blockquote class="claim__content">{{content}}</blockquote>
+      </li>
+    {{/each}}
+    </ul>
+  {{else}}
+    <p class="no-claims">Looks like we didn't see any TV claims over the past day. 🤔🤔🤔</p>
+  {{/if}}
+</div>
+
+<div class="claim-section">
+  <h1 class="claim-section__header">🎭 Social Media Claims 🎭</h1>
+  {{#if claims.SOCIAL.length}}
+    <ul class="claims">
+    {{#each claims.SOCIAL}}
+      <li class="claim" data-platform="{{convertScraperNameToPlatformName scraperName}}">
+        <div class="claim__metadata">
+          <a href="{{canonicalUrl}}" class="claim__permalink">
+            <cite class="claim__speaker">
+              {{speakerName}}
+            </cite>
+            <span class="claim__platform">({{convertScraperNameToPlatformName scraperName}})</span></a>:
+        </div>
+        <blockquote class="claim__content">{{content}}</blockquote>
+      </li>
+    {{/each}}
+    </ul>
+  {{else}}
+    <p class="no-claims">Looks like we didn't see any social media claims over the past day. 🤔🤔🤔</p>
+  {{/if}}
 </div>
 
 {{> boilerplateBottom}}

--- a/src/server/newsletters/templates/nationalText.hbs
+++ b/src/server/newsletters/templates/nationalText.hbs
@@ -3,11 +3,25 @@
 ------
 
 📺 TV CLAIMS 📺
-{{#each tvClaims}}
+{{#each claims.TV}}
 
 {{speakerName}}{{#if source}} on {{ source }}{{/if}} ({{convertScraperNameToPlatformName scraperName}}):
 {{ content }}
 — {{canonicalUrl}}
+{{else}}
+Looks like we didn't see any TV claims over the past day. 🤔🤔🤔
+{{/each}}
+
+------
+
+🎭 SOCIAL MEDIA CLAIMS 🎭
+{{#each claims.SOCIAL}}
+
+{{speakerName}} ({{convertScraperNameToPlatformName scraperName}}):
+{{ content }}
+— {{canonicalUrl}}
+{{else}}
+Looks like we didn't see any social media claims over the past day. 🤔🤔🤔
 {{/each}}
 
 ------

--- a/src/server/newsletters/templates/partials/head.hbs
+++ b/src/server/newsletters/templates/partials/head.hbs
@@ -24,6 +24,10 @@
       font-size: 0.9em;
       color: #666;
     }
+    .no-claims {
+      text-align: center;
+      color: #666;
+    }
     .claim-section {
       margin: 3em 0;
     }

--- a/src/server/utils/templates.js
+++ b/src/server/utils/templates.js
@@ -4,10 +4,11 @@ import sanitizeHTML from 'sanitize-html'
 import juice from 'juice'
 
 import {
-  CLAIM_PLATFORM_NAMES,
+  PLATFORM_NAMES,
 } from '../constants'
 import {
   STATEMENT_SCRAPER_NAMES,
+  STATEMENT_SCRAPER_PLATFORMS,
 } from '../workers/scrapers/constants'
 import {
   getFileContents,
@@ -29,9 +30,9 @@ const registerHandlebarsPartial = (fileName) => {
 
 const registerHandlebarsHelpers = () => {
   Handlebars.registerHelper('convertScraperNameToPlatformName', (scraperName) => {
-    const sharedKey = Object.keys(STATEMENT_SCRAPER_NAMES)
+    const scraper = Object.keys(STATEMENT_SCRAPER_NAMES)
       .find(scraperNameKey => STATEMENT_SCRAPER_NAMES[scraperNameKey] === scraperName)
-    return CLAIM_PLATFORM_NAMES[sharedKey]
+    return PLATFORM_NAMES[STATEMENT_SCRAPER_PLATFORMS[scraper]]
   })
 }
 

--- a/src/server/workers/scrapers/constants.js
+++ b/src/server/workers/scrapers/constants.js
@@ -1,8 +1,19 @@
-// Disabling because we intend to have more exports in the future.
-/* eslint-disable import/prefer-default-export */
+export const STATEMENT_SCRAPERS = {
+  CNN_TRANSCRIPT: 'CNN_TRANSCRIPT',
+  TWITTER_ACCOUNT: 'TWITTER_ACCOUNT',
+}
 
-// Every property of this object should have a corresponding property on `CLAIM_PLATFORM_NAMES`
 export const STATEMENT_SCRAPER_NAMES = {
   CNN_TRANSCRIPT: 'cnnTranscript',
   TWITTER_ACCOUNT: 'twitterAccount',
+}
+
+/**
+ * Maps scrapers to platforms, so that (1) our platform constants don't have to follow the same
+ * taxonomy as the scraper constants, and (2) we can link multiple scrapers to a single platform
+ * (if we ever want to).
+ */
+export const STATEMENT_SCRAPER_PLATFORMS = {
+  CNN_TRANSCRIPT: 'CNN',
+  TWITTER_ACCOUNT: 'TWITTER',
 }


### PR DESCRIPTION
Following on the addition of the `TWITTER_ACCOUNT` scraper, this adds scraped tweets to the National newsletter. There was an unexpected amount of related tinkering to make this work well.

* Change the expected structure of the body data so that a single `claims` object is returned, keyed by medium (currently `TV` and `SOCIAL`).
* Move the generation of the date scope out of the query paramater itself and to an instance attribute set at creation time, so that repeated queries for this instance will share the same scope.
* Add social claims to the newsletter templates.
* Since it's now possible — though weird — for one medium to have claims while the other doesn't, this adds fallback language to each medium's section in the template. (If both media have no claims, the preflight assertion fails and we don't send the newsletter at all.)
* Clean up some of the constants to improve the clarity and purpose of each.

**Note:** We shouldn't actually merge this in until we're scheduling Twitter scraping. We _can_, nothing will _break_, but it'll add an empty "Social Media" section to the National newsletter.

![twitter](https://user-images.githubusercontent.com/4731/63908878-5bb8a780-c9e6-11e9-99ce-d8085596fc2e.jpg)

Resolves #95