### PR TITLE
Change from address to alerts.factstream.co domain

### DIFF
--- a/src/server/workers/mailer/constants.js
+++ b/src/server/workers/mailer/constants.js
@@ -1,4 +1,4 @@
 // Disabling because we intend to have more exports in the future.
 /* eslint-disable import/prefer-default-export */
 
-export const MAILER_FROM_ADDRESS = 'Tech & Check Alerts <alerts@factstream.co>'
+export const MAILER_FROM_ADDRESS = 'Tech & Check Alerts <techandcheck@alerts.factstream.co>'


### PR DESCRIPTION
While not entirely necessary, for best deliverability Mailgun suggests both (1) fully validating the domain by pointing MX records to Mailgun (which means you can’t receive email elsewhere for that domain) and (2) using the validated domain as the domain for the “from” email address.

In order to achieve №1 (a fully-validated domain with MX records) without messing up existing mail delivery to `factstream.co`, we used `alerts.factstream.co`. But then we violated №2 by using `alerts@factstream.co` as the from address, because it's nicer.

However, besides reducing deliverability, this also made some email clients complain (see #166).

So! We decided to pick a more convoluted but also more reliable "from" email address rooted at `alerts.factstream.co` to fix all that.

Resolves #166
Resolves #198
