### PR TITLE
Add twitter kickoff queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "queue:jobs:schedule": "babel-node -- src/scripts/scheduleJobs",
     "queue:jobs:unschedule": "babel-node -- src/scripts/unscheduleJobs",
     "queue:jobs:run:cnn-portal-crawler": "babel-node -- src/scripts/runCnnCrawler",
+    "queue:jobs:run:twitter-scrape-initiation": "babel-node -- src/scripts/runTwitterScraper",
     "mailer:send-test": "babel-node -- src/scripts/sendTestEmail",
     "newsletter:send-test": "babel-node -- src/scripts/sendTestNewsletter",
     "sandbox": "babel-node -- src/scripts/_sandbox",

--- a/src/scripts/runTwitterScraper.js
+++ b/src/scripts/runTwitterScraper.js
@@ -1,0 +1,22 @@
+import twitterScrapeInitiationQueueDict from '../server/queues/twitterScrapeInitiationQueue'
+import twitterAccountStatementScraperQueueDict from '../server/queues/twitterAccountStatementScraperQueue'
+import claimBusterClaimDetectorQueueDict from '../server/queues/claimBusterClaimDetectorQueue'
+
+import {
+  getQueueFromQueueDict,
+  startQueueProcessors,
+} from '../server/utils/queue'
+import logger from '../server/utils/logger'
+
+const twitterScrapeInitiationQueue = getQueueFromQueueDict(
+  twitterScrapeInitiationQueueDict,
+)
+twitterScrapeInitiationQueue.add()
+
+startQueueProcessors([
+  twitterScrapeInitiationQueueDict,
+  twitterAccountStatementScraperQueueDict,
+  claimBusterClaimDetectorQueueDict,
+])
+
+logger.info('The twitter crawler is running; you will have to manually exit this process.')

--- a/src/server/queues/constants.js
+++ b/src/server/queues/constants.js
@@ -20,6 +20,7 @@ export const QueueNames = {
   scraperQueues: {
     CNN_TRANSCRIPT_STATEMENT: 'cnnTranscriptStatementScraper',
     TWITTER_ACCOUNT_STATEMENT: 'twitterAccountStatementScraper',
+    TWITTER_SCRAPE_INITITATION: 'twitterScrapeInitiation',
   },
   claimDetectorQueues: {
     CLAIM_BUSTER: 'claimBusterClaimDetector',

--- a/src/server/queues/twitterScrapeInitiationQueue/TwitterScrapeInitiationJobScheduler.js
+++ b/src/server/queues/twitterScrapeInitiationQueue/TwitterScrapeInitiationJobScheduler.js
@@ -1,0 +1,11 @@
+import TwitterScrapeInitiationQueueFactory from './TwitterScrapeInitiationQueueFactory'
+import AbstractJobScheduler from '../AbstractJobScheduler'
+import { Schedules } from '../constants'
+
+class TwitterScrapeInitiationJobScheduler extends AbstractJobScheduler {
+  getScheduleCron = () => Schedules.EVERY_HOUR
+
+  getQueueFactory = () => new TwitterScrapeInitiationQueueFactory()
+}
+
+export default TwitterScrapeInitiationJobScheduler

--- a/src/server/queues/twitterScrapeInitiationQueue/TwitterScrapeInitiationQueueFactory.js
+++ b/src/server/queues/twitterScrapeInitiationQueue/TwitterScrapeInitiationQueueFactory.js
@@ -1,0 +1,10 @@
+import { QueueNames } from '../constants'
+import AbstractQueueFactory from '../AbstractQueueFactory'
+
+class TwitterScrapeInitiationQueueFactory extends AbstractQueueFactory {
+  getQueueName = () => QueueNames.scraperQueues.TWITTER_SCRAPE_INITITATION
+
+  getPathToProcessor = () => `${__dirname}/twitterScrapeInitiationJobProcessor.js`
+}
+
+export default TwitterScrapeInitiationQueueFactory

--- a/src/server/queues/twitterScrapeInitiationQueue/index.js
+++ b/src/server/queues/twitterScrapeInitiationQueue/index.js
@@ -1,0 +1,9 @@
+import TwitterScrapeInitiationQueueFactory from './TwitterScrapeInitiationQueueFactory'
+import TwitterScrapeInitiationJobScheduler from './TwitterScrapeInitiationJobScheduler'
+import twitterScrapeInitiationJobProcessor from './twitterScrapeInitiationJobProcessor'
+
+export default {
+  factory: new TwitterScrapeInitiationQueueFactory(),
+  scheduler: new TwitterScrapeInitiationJobScheduler(),
+  processor: twitterScrapeInitiationJobProcessor,
+}

--- a/src/server/queues/twitterScrapeInitiationQueue/twitterScrapeInitiationJobProcessor.js
+++ b/src/server/queues/twitterScrapeInitiationQueue/twitterScrapeInitiationJobProcessor.js
@@ -1,0 +1,21 @@
+import twitterAccountStatementScraperQueueDict from '../twitterAccountStatementScraperQueue'
+import models from '../../models'
+import { getQueueFromQueueDict } from '../../utils/queue'
+
+const { TwitterAccount } = models
+
+const twitterAccountStatementScraperQueue = getQueueFromQueueDict(
+  twitterAccountStatementScraperQueueDict,
+)
+
+const scrapeTwitterAccount = twitterAccount => twitterAccountStatementScraperQueue.add({
+  screenName: twitterAccount.screenName,
+})
+
+const getAllTwitterAccounts = () => TwitterAccount.findAll()
+
+export default async () => {
+  const twitterAccounts = await getAllTwitterAccounts()
+  twitterAccounts.forEach(scrapeTwitterAccount)
+  return twitterAccounts
+}

--- a/src/server/utils/__test__/claimBuster.test.js
+++ b/src/server/utils/__test__/claimBuster.test.js
@@ -1,5 +1,6 @@
 import {
   filterWeakClaims,
+  cleanTextForClaimBuster,
 } from '../claimBuster'
 
 import { CLAIMBUSTER_THRESHHOLD } from '../../constants'
@@ -30,5 +31,18 @@ describe('filterWeakClaims', () => {
         expect(results).toContainEqual(input)
       }
     })
+  })
+})
+
+describe('cleanTextForClaimBuster', () => {
+  it('Should remove slashes', () => {
+    expect(cleanTextForClaimBuster('this / or / that'))
+      .toBe('this or that')
+  })
+  it('Should remove newlines', () => {
+    expect(cleanTextForClaimBuster(`first sentence
+second sentence.
+third sentence.`))
+      .toBe('first sentence second sentence. third sentence.')
   })
 })

--- a/src/server/utils/claimBuster.js
+++ b/src/server/utils/claimBuster.js
@@ -1,7 +1,27 @@
-// Disabling because we intend to have more exports in the future.
-/* eslint-disable import/prefer-default-export */
-
+import {
+  runSequence,
+  squish,
+} from '.'
 import { CLAIMBUSTER_THRESHHOLD } from '../constants'
 
 export const filterWeakClaims = claimBusterResults => claimBusterResults
   .filter(result => result.score > CLAIMBUSTER_THRESHHOLD)
+
+const removeUnfriendlyCharacters = string => string.replace(/\//g, '')
+
+
+/**
+ * This cleans up statement text to match ClaimBuster API requirements.
+ *
+ * This method will change as the integration with ClaimBuster is updated.
+ *
+ * @param  {String} statementText The raw statement text to be passed to ClaimBuster
+ * @return {String}               The sanitized, ClaimBuster friendly statement text
+ */
+export const cleanTextForClaimBuster = statementText => runSequence(
+  [
+    removeUnfriendlyCharacters,
+    squish,
+  ],
+  statementText,
+)

--- a/src/server/workers/claimDetectors/ClaimBusterClaimDetector.js
+++ b/src/server/workers/claimDetectors/ClaimBusterClaimDetector.js
@@ -1,5 +1,8 @@
 import rp from 'request-promise'
-import { filterWeakClaims } from '../../utils/claimBuster'
+import {
+  filterWeakClaims,
+  cleanTextForClaimBuster,
+} from '../../utils/claimBuster'
 
 class ClaimBusterClaimDetector {
   constructor(statement) {
@@ -14,7 +17,8 @@ class ClaimBusterClaimDetector {
       scraperName,
       source,
     } = this.statement
-    const uri = `https://idir.uta.edu/factchecker/score_text/${statementText}`
+    const urlSafeStatementText = encodeURIComponent(cleanTextForClaimBuster(statementText))
+    const uri = `https://idir.uta.edu/factchecker/score_text/${urlSafeStatementText}`
     return rp
       .get({
         uri,


### PR DESCRIPTION
*NOTE: Review #203 first, then we need to merge and potentially rebase before reviewing this (this contains all of the changes of 203)*

With this PR the twitter scraper will actually work (note that it won't scrape anything unless the twitter_accounts table has data in it).

This also adds a utility script similar to the cnn pipeline utility script, which allows you to manually run the twitter scrape pipeline for testing purposes.

Since this actually invokes the twitter pipeline we also learned about a few kinks in claimbuster; specifically that claimbuster can't handle statements with forward slashes (e.g. tweets containing urls).

Issue #26 
Resolves #204 