### PR TITLE
Fetch claims with more stable time window

### DIFF
--- a/src/server/newsletters/NationalNewsletter.js
+++ b/src/server/newsletters/NationalNewsletter.js
@@ -15,15 +15,6 @@ import {
 const { Claim } = models
 
 class NationalNewsletter extends AbstractNewsletter {
-  constructor() {
-    super()
-    /**
-     * This is the date we use to scope our claim queries; by storing it instead of generating it
-     * on the fly, we can ensure all `fetchClaimsByMedium()` results share the same date scope.
-     */
-    this.createdAtHorizon = dayjs().subtract(1, 'day')
-  }
-
   getMailingList = () => MAILING_LISTS.NATIONAL
 
   getPathToTemplate = () => `${__dirname}/templates/national.hbs`
@@ -62,7 +53,8 @@ class NationalNewsletter extends AbstractNewsletter {
         [Sequelize.Op.in]: this.getScraperNamesByMedium()[medium],
       },
       createdAt: {
-        [Sequelize.Op.gte]: this.createdAtHorizon.format(),
+        [Sequelize.Op.gte]: dayjs().startOf('hour').subtract(1, 'day').format(),
+        [Sequelize.Op.lt]: dayjs().startOf('hour').format(),
       },
     },
     order: [


### PR DESCRIPTION
Before, the time window we used for fetching claims for the newsletter was problematic in two ways:

1. The starting point for calculating the 24-hour time window was the moment the class was created; thus, tiny variations in starting time each day could result in sequential days either overlapping their time windows or leaving a gap between them.
2. We used an unbounded `>=` query, which introduced another possibility of duplicate claims on sequential days.

This resolves (1) by backing the query up to the start of the hour to round off any drift in start time and (2) setting a hard `<` bound on the upper end of the query.

As a bonus, we can remove the slightly gross use of `this.createdAtHorizon`, since the time drift between medium queries that it resolved is now avoided.

Resolves #206