### PR TITLE
Fetch full tweets using Twitter API extended mode

### DIFF
--- a/src/server/utils/__test__/twitter.test.js
+++ b/src/server/utils/__test__/twitter.test.js
@@ -12,7 +12,7 @@ import {
 
 const exampleTweet = {
   id_str: '12345',
-  text: 'Text',
+  full_text: 'Text',
   user: {
     name: 'Name',
     screen_name: 'screenName',
@@ -67,7 +67,7 @@ describe('extractStatementsFromTweets', () => {
           name: exampleTweet.user.name,
           affiliation: exampleTweet.user.description,
         },
-        text: exampleTweet.text,
+        text: exampleTweet.full_text,
         canonicalUrl: `https://twitter.com/${exampleTweet.user.screen_name}/status/${exampleTweet.id_str}`,
         source: exampleTweet.user.screen_name,
       }])
@@ -94,7 +94,7 @@ describe('getSourceFromTweet', () => {
 describe('getTextFromTweet', () => {
   it('Should pull the text from a tweet', () => {
     expect(getTextFromTweet(exampleTweet))
-      .toEqual(exampleTweet.text)
+      .toEqual(exampleTweet.full_text)
   })
 })
 describe('getSpeakerAffiliationFromTweet', () => {

--- a/src/server/utils/twitter.js
+++ b/src/server/utils/twitter.js
@@ -1,6 +1,15 @@
+import querystring from 'querystring'
+
 export const isTwitterScreenName = screenName => /^@?(\w){1,15}$/.test(screenName)
 
-export const getTwitterApiUrlForUserTimeline = screenName => `https://api.twitter.com/1.1/statuses/user_timeline.json?screen_name=${screenName}&include_rts=false&tweet_mode=extended`
+export const getTwitterApiUrlForUserTimeline = (screenName) => {
+  const params = {
+    screen_name: screenName,
+    include_rts: false,
+    tweet_mode: 'extended',
+  }
+  return `https://api.twitter.com/1.1/statuses/user_timeline.json?${querystring.stringify(params)}`
+}
 
 export const parseJsonIntoTweets = input => JSON.parse(input)
 

--- a/src/server/utils/twitter.js
+++ b/src/server/utils/twitter.js
@@ -1,6 +1,6 @@
 export const isTwitterScreenName = screenName => /^@?(\w){1,15}$/.test(screenName)
 
-export const getTwitterApiUrlForUserTimeline = screenName => `https://api.twitter.com/1.1/statuses/user_timeline.json?screen_name=${screenName}&include_rts=false`
+export const getTwitterApiUrlForUserTimeline = screenName => `https://api.twitter.com/1.1/statuses/user_timeline.json?screen_name=${screenName}&include_rts=false&tweet_mode=extended`
 
 export const parseJsonIntoTweets = input => JSON.parse(input)
 
@@ -10,7 +10,7 @@ export const getSpeakerNameFromTweet = tweet => tweet.user.name
 
 export const getSourceFromTweet = tweet => tweet.user.screen_name
 
-export const getTextFromTweet = tweet => tweet.text
+export const getTextFromTweet = tweet => tweet.full_text
 
 export const getSpeakerAffiliationFromTweet = tweet => tweet.user.description
 


### PR DESCRIPTION
For backwards-compatibility with clients expecting Twitter’s original 140-character limit, the Twitter API truncates tweets by default. You have to explicitly request the longer versions, and change which field you read the tweet content from.

This adds the necessary parameter and modifies which field we draw the tweet content from.

It also changes how we compose the query string parameters from a long direct string manipulation to an object-to-query-string conversion using Node's built-in `querystring`.

Resolves #213