### PR TITLE
Automated automated testing for CNN pipeline

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,25 @@
+# Testing
+
+We use [jest](https://jestjs.io/) for automated tests in this project.
+
+We asipre to have a full blown robust unit and integration test suite, but for now there is a bit of discretion around what exactly warrants a new set of tests (e.g. we are not testing code that relies on external resources such as databases or HTTP responses).
+
+Still: if you write code that can be tested, please ensure all PRs include tests of that code.
+
+## Generating tests for the CNN scraper
+Since the CNN transcript scraper pipeline is fairly complex, we've created a tool to generate new unit tests for each step of the pipeline whenever we find a transcript that causes trouble.
+
+## To create a test suite for a transcript that is being processed properly:
+
+1. run `yarn generate:test:cnn -u [FULL_TRANSCRIPT_URL_HERE]`
+
+## To debug and correct the pipeline for a transcript that is not being processed properly:
+
+1. run `yarn generate:test:cnn -u [FULL_TRANSCRIPT_URL_HERE]`
+2. Open up the new test suite directory in `/src/server/utils/__test__/data/cnn`. The suite directories reflect the suite index.  Indexes are sequential and auto increment, so the new suite will be in the highest numbered directory.
+3. Find *the FIRST step* in the pipeline that failed (of the form `STEP_stepname.json`, e.g. `8_cleanStatementSpeakerNames.json`).
+4. Correct the output attribute of that step to match whatever it should be.  The tests should now fail, since you have changed the test's expected output and it doesn't match what that step actually produced.
+5. Make the appropriate corrections to the code so that all tests pass again.
+6. Re-generate your new test suite by running `yarn generate:test:cnn -i [TEST_SUITE_INDEX]` (e.g. directory number).  This action ensures that the full pipeline reflects the output of the now corrected step.
+7. Verify that the final output is now what you expect.  If not, go back to step 3.
+8. Commit your code correction and the entire new test suite.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -2,24 +2,25 @@
 
 We use [jest](https://jestjs.io/) for automated tests in this project.
 
-We asipre to have a full blown robust unit and integration test suite, but for now there is a bit of discretion around what exactly warrants a new set of tests (e.g. we are not testing code that relies on external resources such as databases or HTTP responses).
+We aspire to have a full-blown robust unit and integration test suite, but for now there is a bit of discretion around what exactly warrants a new set of tests.  E.g., we are not testing code that relies on external resources such as databases or HTTP responses.
 
 Still: if you write code that can be tested, please ensure all PRs include tests of that code.
 
 ## Generating tests for the CNN scraper
+
 Since the CNN transcript scraper pipeline is fairly complex, we've created a tool to generate new unit tests for each step of the pipeline whenever we find a transcript that causes trouble.
 
-## To create a test suite for a transcript that is being processed properly:
+### To create a test suite for a transcript that is being processed properly:
 
-1. run `yarn generate:test:cnn -u [FULL_TRANSCRIPT_URL_HERE]`
+1. Run `yarn generate:test:cnn -u {FULL_TRANSCRIPT_URL_HERE}`
 
-## To debug and correct the pipeline for a transcript that is not being processed properly:
+### To debug and correct the pipeline for a transcript that is not being processed properly:
 
-1. run `yarn generate:test:cnn -u [FULL_TRANSCRIPT_URL_HERE]`
-2. Open up the new test suite directory in `/src/server/utils/__test__/data/cnn`. The suite directories reflect the suite index.  Indexes are sequential and auto increment, so the new suite will be in the highest numbered directory.
-3. Find *the FIRST step* in the pipeline that failed (of the form `STEP_stepname.json`, e.g. `8_cleanStatementSpeakerNames.json`).
+1. Create a test suite (see above)
+2. Open up the new test suite directory in `/src/server/utils/__test__/data/cnn`.  The suite directories reflect the suite index.  Indices are sequential and auto increment, so the new suite will be in the highest-numbered directory.
+3. Find *the FIRST step* in the pipeline that failed (of the form `{stepNumber}_{stepName}.json`, e.g. `8_cleanStatementSpeakerNames.json`).
 4. Correct the output attribute of that step to match whatever it should be.  The tests should now fail, since you have changed the test's expected output and it doesn't match what that step actually produced.
 5. Make the appropriate corrections to the code so that all tests pass again.
-6. Re-generate your new test suite by running `yarn generate:test:cnn -i [TEST_SUITE_INDEX]` (e.g. directory number).  This action ensures that the full pipeline reflects the output of the now corrected step.
+6. Regenerate your new test suite by running `yarn generate:test:cnn -i {TEST_SUITE_INDEX}` (i.e., directory number).  This action ensures that the full pipeline reflects the output of the now-corrected step.
 7. Verify that the final output is now what you expect.  If not, go back to step 3.
 8. Commit your code correction and the entire new test suite.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "newsletter:send-test": "babel-node -- src/scripts/sendTestNewsletter",
     "sandbox": "babel-node -- src/scripts/_sandbox",
     "scrape:cnn": "babel-node -- src/scripts/scrapeCnnStatements",
-    "scrape:twitter": "babel-node -- src/scripts/scrapeTwitterStatements"
+    "scrape:twitter": "babel-node -- src/scripts/scrapeTwitterStatements",
+    "generate:test:cnn": "babel-node -- src/scripts/generateCnnUtilTest"
   },
   "devDependencies": {
     "@babel/core": "^7.4.4",

--- a/src/scripts/generateCnnUtilTest.js
+++ b/src/scripts/generateCnnUtilTest.js
@@ -1,0 +1,157 @@
+import fs from 'fs'
+import GenericScraper from '../server/workers/scrapers/GenericScraper'
+import {
+  isTranscriptUrl,
+  getTranscriptTextFromHtml,
+  removeTimestamps,
+  removeSpeakerReminders,
+  removeDescriptors,
+  addBreaksOnSpeakerChange,
+  splitTranscriptIntoChunks,
+  extractStatementsFromChunks,
+  cleanStatementSpeakerNames,
+  normalizeStatementSpeakers,
+  removeNetworkAffiliatedStatements,
+  removeUnattributableStatements,
+} from '../server/utils/cnn'
+import logger from '../server/utils/logger'
+
+const FILE_ENCODING = 'utf8'
+const BASE_PATH = `${__dirname}/../server/utils/__test__/data/cnn`
+
+const scrapeSequence = [
+  getTranscriptTextFromHtml,
+  removeTimestamps,
+  removeSpeakerReminders,
+  removeDescriptors,
+  addBreaksOnSpeakerChange,
+  splitTranscriptIntoChunks,
+  extractStatementsFromChunks,
+  cleanStatementSpeakerNames,
+  normalizeStatementSpeakers,
+  removeNetworkAffiliatedStatements,
+  removeUnattributableStatements,
+]
+
+const getTestSuiteIndex = () => {
+  const indexFlag = process.argv.indexOf('-i')
+  if (indexFlag !== -1) {
+    const suiteIndex = process.argv[indexFlag + 1]
+    return suiteIndex
+  }
+  return null
+}
+
+const getUrl = () => {
+  const urlFlag = process.argv.indexOf('-u')
+  if (urlFlag !== -1) {
+    const url = process.argv[urlFlag + 1]
+    if (isTranscriptUrl(url)) {
+      return url
+    }
+  }
+  return null
+}
+
+const getTestSuiteDirectoryPath = suiteIndex => `${BASE_PATH}/${suiteIndex}`
+
+const getTestSuiteUrlPath = (suiteIndex) => {
+  const testSuiteDirectoryPath = getTestSuiteDirectoryPath(suiteIndex)
+  return `${testSuiteDirectoryPath}/_url.txt`
+}
+
+const getTestSuiteStepPath = (suiteIndex, stepIndex, stepName) => `${getTestSuiteDirectoryPath(suiteIndex)}/${stepIndex}_${stepName}.json`
+
+const getUrlFromTestSuite = (suiteIndex) => {
+  try {
+    return fs.readFileSync(getTestSuiteUrlPath(suiteIndex), FILE_ENCODING)
+  } catch {
+    return null
+  }
+}
+
+// This method is a bit magic.  It gets a list of all existing files in the suites directory
+// and then finds the file with the highest number name (index).
+const getNextTestSuiteIndex = () => {
+  const testSuiteIndexes = fs
+    .readdirSync(BASE_PATH) // Get the files
+    .map(fileName => parseInt(fileName, 10)) // Convert the names to numbers
+    .filter(Number.isInteger) // Get rid of anything that wasn't a number
+    .sort((a, b) => a - b) // Sort numerically
+  return testSuiteIndexes.length === 0 ? 1 : testSuiteIndexes.slice(-1)[0] + 1
+}
+
+const createTestSuiteDirectory = (suiteIndex) => {
+  const dirPath = getTestSuiteDirectoryPath(suiteIndex)
+  try {
+    if (!fs.existsSync(dirPath)) {
+      fs.mkdirSync(dirPath)
+    }
+  } catch (e) {
+    logger.error(e)
+  }
+}
+
+const saveTestUrl = (suiteIndex, url) => {
+  try {
+    fs.writeFileSync(
+      getTestSuiteUrlPath(suiteIndex),
+      url,
+      { encoding: FILE_ENCODING },
+    )
+  } catch (e) {
+    logger.error(e)
+  }
+}
+
+const saveTestStep = (suiteIndex, stepIndex, stepName, input, output) => {
+  const testStepContent = {
+    functionName: stepName,
+    input,
+    output,
+  }
+  const testStepPath = getTestSuiteStepPath(suiteIndex, stepIndex, stepName)
+  try {
+    fs.writeFileSync(
+      testStepPath,
+      JSON.stringify(testStepContent, null, 2),
+      { encoding: FILE_ENCODING },
+    )
+  } catch (e) {
+    logger.error(e)
+  }
+}
+
+const generateTestSuiteFromSequence = (suiteIndex, sequence, seed) => sequence
+  .reduce((param, fn, stepIndex) => {
+    const result = fn(param)
+    saveTestStep(
+      suiteIndex,
+      stepIndex + 1,
+      fn.name,
+      param,
+      result,
+    )
+    return result
+  }, seed)
+
+const scrapeRawTranscript = (url) => {
+  const scraper = new GenericScraper(url)
+  return scraper.run()
+}
+
+const testSuiteIndex = getTestSuiteIndex()
+const currentIndex = testSuiteIndex || getNextTestSuiteIndex()
+const currentUrl = getUrl() || getUrlFromTestSuite(currentIndex)
+
+if (!currentUrl) {
+  logger.error('Pass in a valid CNN transcript URL with the `-u` parameter, or a suite index to re-run with the `-i` parameter')
+  process.exit()
+}
+
+createTestSuiteDirectory(currentIndex)
+saveTestUrl(currentIndex, currentUrl)
+scrapeRawTranscript(currentUrl)
+  .then(scrapeResult => generateTestSuiteFromSequence(currentIndex, scrapeSequence, scrapeResult))
+  .catch(error => logger.error(`Scraping failed. ${error}`))
+  .finally(() => process.exit())

--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -2,6 +2,7 @@ import {
   isTranscriptListUrl,
   isTranscriptUrl,
   getFullCnnUrl,
+  getTranscriptTextFromHtml,
   extractPublicationDateFromTranscriptUrl,
   removeTimestamps,
   removeSpeakerReminders,
@@ -27,9 +28,36 @@ import {
   removeNetworkAffiliatedStatements,
   removeUnattributableStatements,
 } from '../cnn'
+import testSuites from './data/cnn'
 
+const runTestSuite = (fn) => {
+  if (fn.name in testSuites) {
+    testSuites[fn.name].forEach(test => it(`Should pass for ${test.filePath}`, () => {
+      expect(fn(test.data.input))
+        .toEqual(test.data.output)
+    }))
+  }
+}
+
+const runTestSuites = arr => arr.map(fn => describe(`${fn.name} (Suite)`, () => runTestSuite(fn)))
 
 describe('utils/cnn', () => {
+  describe('suites', () => {
+    runTestSuites([
+      getTranscriptTextFromHtml,
+      removeTimestamps,
+      removeSpeakerReminders,
+      removeDescriptors,
+      addBreaksOnSpeakerChange,
+      splitTranscriptIntoChunks,
+      extractStatementsFromChunks,
+      cleanStatementSpeakerNames,
+      normalizeStatementSpeakers,
+      removeNetworkAffiliatedStatements,
+      removeUnattributableStatements,
+    ])
+  })
+
   describe('isTranscriptListUrl', () => {
     it('Should not improperly identify transcript list URLs', () => {
       expect(isTranscriptListUrl('http://google.com'))

--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -49,6 +49,10 @@ describe('utils/cnn', () => {
     it('Should identify transcript list URLs', () => {
       expect(isTranscriptUrl('/TRANSCRIPTS/1906/01/cnr.20.html'))
         .toBe(true)
+      expect(isTranscriptUrl('https://transcripts.cnn.com/TRANSCRIPTS/1906/01/cnr.20.html'))
+        .toBe(true)
+      expect(isTranscriptUrl('http://transcripts.cnn.com/TRANSCRIPTS/1906/01/cnr.20.html'))
+        .toBe(true)
     })
   })
 

--- a/src/server/utils/__test__/data/cnn/index.js
+++ b/src/server/utils/__test__/data/cnn/index.js
@@ -1,0 +1,38 @@
+import fs from 'fs'
+
+const testSuiteBasePath = `${__dirname}`
+const testSuites = {}
+
+const isJsonFile = fileName => fileName.endsWith('.json')
+
+const loadTestSuite = suitePath => fs
+  .readdirSync(suitePath)
+  .filter(isJsonFile)
+  .map((fileName) => {
+    const filePath = `${suitePath}/${fileName}`
+    const rawData = fs.readFileSync(filePath)
+    const parsedData = JSON.parse(rawData)
+    const { functionName } = parsedData
+    testSuites[functionName] = testSuites[functionName] || []
+    const newTestItem = {
+      filePath,
+      data: parsedData,
+    }
+    testSuites[functionName].push(newTestItem)
+    return newTestItem
+  })
+
+const loadAllTestSuites = () => fs
+  .readdirSync(testSuiteBasePath)
+  .map((fileName) => {
+    const fullPath = `${testSuiteBasePath}/${fileName}`
+    const isDirectory = fs.lstatSync(fullPath).isDirectory()
+    if (isDirectory) {
+      loadTestSuite(fullPath)
+    }
+    return null
+  })
+
+loadAllTestSuites()
+
+export default testSuites

--- a/src/server/utils/cnn.js
+++ b/src/server/utils/cnn.js
@@ -26,7 +26,9 @@ const chunkAttributionRegex = /[^a-z]+[:]/
 export const isTranscriptListUrl = url => url.startsWith('/TRANSCRIPTS/')
   && url.endsWith('.html')
 
-export const isTranscriptUrl = url => url.startsWith('/TRANSCRIPTS/')
+export const isTranscriptUrl = url => (url.startsWith('/TRANSCRIPTS/')
+  || url.startsWith('https://transcripts.cnn.com/TRANSCRIPTS/')
+  || url.startsWith('http://transcripts.cnn.com/TRANSCRIPTS/'))
   && url.endsWith('.html')
 
 export const getFullCnnUrl = (url) => {

--- a/src/server/utils/cnn.js
+++ b/src/server/utils/cnn.js
@@ -1,7 +1,9 @@
+import cheerio from 'cheerio'
 import dayjs from 'dayjs'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
 
 dayjs.extend(customParseFormat)
+const $ = cheerio
 
 /**
  * @typedef {Object} Speaker
@@ -55,6 +57,20 @@ export const extractPublicationDateFromTranscriptUrl = (url) => {
   const month = parts[2].substring(2)
   const day = parts[3]
   return dayjs(`${month}/${day}/${year}`, 'MM/DD/YY')
+}
+
+/**
+ * Extract transcript text from HTML that has been scraped from a CNN transcript
+ * @param  {String} html The raw html that was returned from a scrape
+ * @return {String}      The transcript text from that html
+ */
+export const getTranscriptTextFromHtml = (html) => {
+  const $bodyTextElements = $(html).find('.cnnBodyText')
+  const bodyTexts = $bodyTextElements.map((i, element) => $(element).text())
+  if (bodyTexts.length < 3) {
+    throw new Error('The html provided was an unexpected transcript format.')
+  }
+  return bodyTexts[2]
 }
 
 /**

--- a/src/server/workers/scrapers/GenericScraper.js
+++ b/src/server/workers/scrapers/GenericScraper.js
@@ -1,0 +1,10 @@
+import AbstractScraper from './AbstractScraper'
+import { STATEMENT_SCRAPER_NAMES } from './constants'
+
+class GenericScraper extends AbstractScraper {
+  getScraperName = () => STATEMENT_SCRAPER_NAMES.GENERIC
+
+  scrapeHandler = async responseString => responseString
+}
+
+export default GenericScraper

--- a/src/server/workers/scrapers/constants.js
+++ b/src/server/workers/scrapers/constants.js
@@ -8,6 +8,10 @@ export const STATEMENT_SCRAPER_NAMES = {
   TWITTER_ACCOUNT: 'twitterAccount',
 }
 
+export const SCRAPER_NAMES = {
+  GENERIC: 'generic',
+}
+
 /**
  * Maps scrapers to platforms, so that (1) our platform constants don't have to follow the same
  * taxonomy as the scraper constants, and (2) we can link multiple scrapers to a single platform


### PR DESCRIPTION
This PR creates a mechanism (and utility) for us to easily expand the CNN test suite to include real world data as we find instances of the system failing.

For documentation on how to use these tools meaningfully go check the new `docs/TESTING.md` which is part of this PR.

run `yarn generate:test:cnn -u [FULL_TRANSCRIPT_URL_HERE]`

Resolves #127 
Related to #47 since we technically now have TESTING.md