### PR TITLE
Fix util import

### DIFF
--- a/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
+++ b/src/server/workers/scrapers/CnnTranscriptStatementScraper.js
@@ -1,11 +1,10 @@
 import cheerio from 'cheerio'
 import memoizeOne from 'memoize-one'
-
-import runSequence from '../../utils'
 import logger from '../../utils/logger'
 
 import { STATEMENT_SCRAPER_NAMES } from './constants'
 
+import { runSequence } from '../../utils'
 import {
   squishStatementsText,
 } from '../../utils/scraper'


### PR DESCRIPTION
We accidentally approved some buggy code recently.  This fixes the CNN scraper again.

To test the CNN scraper type:

```
yarn scrape:cnn -u /TRANSCRIPTS/1908/22/cnnt.01.html
```

This is a hotfix; no issue.  If @reefdog can't review I'll just merge since this is a breaking bug.