### PR TITLE
Increase length of scrape_logs.scrape_url field

### DIFF
--- a/src/server/migrations/20190912192137-change-scrape-url-type.js
+++ b/src/server/migrations/20190912192137-change-scrape-url-type.js
@@ -1,0 +1,8 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.changeColumn('scrape_logs', 'scrape_url', {
+    type: Sequelize.STRING(1024),
+  }),
+  down: (queryInterface, Sequelize) => queryInterface.changeColumn('scrape_logs', 'scrape_url', {
+    type: Sequelize.STRING,
+  }),
+}

--- a/src/server/models/ScrapeLog.js
+++ b/src/server/models/ScrapeLog.js
@@ -1,6 +1,6 @@
 module.exports = (sequelize, DataTypes) => {
   const ScrapeLog = sequelize.define('ScrapeLog', {
-    scrapeUrl: DataTypes.STRING,
+    scrapeUrl: DataTypes.STRING(1024),
     scraperName: DataTypes.STRING,
     result: DataTypes.TEXT,
     error: DataTypes.TEXT,


### PR DESCRIPTION
Previously, we defined the `ScrapeLog.scrapeUrl` attribute (in Postgres terms, `scrape_logs.scrape_url`) using the Sequelize `STRING` shorthand with no length, which meant it defaulted to 255. As with `StatementLog.canonicalUrl`, a more appropriate length for URLs is 1024.

This adjusts the model definition and adds a Sequelize migration to change the database column. Consequently, you should run migrations after merging this commit.

Resolves #242