### PR TITLE
Repair North Carolina queue factory

### DIFF
--- a/src/server/queues/constants.js
+++ b/src/server/queues/constants.js
@@ -27,5 +27,6 @@ export const QueueNames = {
   },
   newsletterDeliveryQueues: {
     NATIONAL: 'nationalNewsletterDelivery',
+    NORTH_CAROLINA: 'northCarolinaNewsletterDelivery',
   },
 }

--- a/src/server/queues/northCarolinaNewsletterDeliveryQueue/NorthCarolinaNewsletterDeliveryQueueFactory.js
+++ b/src/server/queues/northCarolinaNewsletterDeliveryQueue/NorthCarolinaNewsletterDeliveryQueueFactory.js
@@ -2,7 +2,7 @@ import { QueueNames } from '../constants'
 import AbstractQueueFactory from '../AbstractQueueFactory'
 
 class NorthCarolinaNewsletterDeliveryQueueFactory extends AbstractQueueFactory {
-  getQueueName = () => QueueNames.newsletterDeliveryQueues.NATIONAL
+  getQueueName = () => QueueNames.newsletterDeliveryQueues.NORTH_CAROLINA
 
   getPathToProcessor = () => `${__dirname}/northCarolinaNewsletterDeliveryJobProcessor.js`
 }


### PR DESCRIPTION
The North Carolina newsletter components were created from copying the National one, but we left behind a reference to the National queue.

This fixes that by correctly describing and using a North Carolina queue.

Hopefully someone will actually review this one.

Resolves #246