### PR TITLE
Match up Claims table and model definitions

### DIFF
--- a/src/server/migrations/20190915180014-increase-claim-column-length.js
+++ b/src/server/migrations/20190915180014-increase-claim-column-length.js
@@ -1,39 +1,46 @@
 import { runPromiseSequence } from '../utils'
 
 module.exports = {
-  up: (queryInterface, Sequelize) => runPromiseSequence([
-    () => queryInterface.changeColumn(
-      'claims',
-      'source',
-      Sequelize.STRING(1024),
-    ),
-    () => queryInterface.changeColumn(
-      'claims',
-      'speaker_name',
-      Sequelize.STRING(1024),
-    ),
-    () => queryInterface.changeColumn(
-      'claims',
-      'speaker_affiliation',
-      Sequelize.STRING(1024),
-    ),
-  ]),
-
-  down: (queryInterface, Sequelize) => runPromiseSequence([
-    () => queryInterface.changeColumn(
-      'claims',
-      'source',
-      Sequelize.STRING,
-    ),
-    () => queryInterface.changeColumn(
-      'claims',
-      'speaker_name',
-      Sequelize.STRING,
-    ),
-    () => queryInterface.changeColumn(
-      'claims',
-      'speaker_affiliation',
-      Sequelize.STRING,
-    ),
-  ]),
+  up: (queryInterface, Sequelize) => queryInterface.sequelize
+    .transaction(t => runPromiseSequence([
+      () => queryInterface.changeColumn(
+        'claims',
+        'source',
+        Sequelize.STRING(1024),
+        { transaction: t },
+      ),
+      () => queryInterface.changeColumn(
+        'claims',
+        'speaker_name',
+        Sequelize.STRING(1024),
+        { transaction: t },
+      ),
+      () => queryInterface.changeColumn(
+        'claims',
+        'speaker_affiliation',
+        Sequelize.STRING(1024),
+        { transaction: t },
+      ),
+    ])),
+  down: (queryInterface, Sequelize) => queryInterface.sequelize
+    .transaction(t => runPromiseSequence([
+      () => queryInterface.changeColumn(
+        'claims',
+        'source',
+        Sequelize.STRING,
+        { transaction: t },
+      ),
+      () => queryInterface.changeColumn(
+        'claims',
+        'speaker_name',
+        Sequelize.STRING,
+        { transaction: t },
+      ),
+      () => queryInterface.changeColumn(
+        'claims',
+        'speaker_affiliation',
+        Sequelize.STRING,
+        { transaction: t },
+      ),
+    ])),
 }

--- a/src/server/migrations/20190915180014-increase-claim-column-length.js
+++ b/src/server/migrations/20190915180014-increase-claim-column-length.js
@@ -1,0 +1,39 @@
+import { runPromiseSequence } from '../utils'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => runPromiseSequence([
+    () => queryInterface.changeColumn(
+      'claims',
+      'source',
+      Sequelize.STRING(1024),
+    ),
+    () => queryInterface.changeColumn(
+      'claims',
+      'speaker_name',
+      Sequelize.STRING(1024),
+    ),
+    () => queryInterface.changeColumn(
+      'claims',
+      'speaker_affiliation',
+      Sequelize.STRING(1024),
+    ),
+  ]),
+
+  down: (queryInterface, Sequelize) => runPromiseSequence([
+    () => queryInterface.changeColumn(
+      'claims',
+      'source',
+      Sequelize.STRING,
+    ),
+    () => queryInterface.changeColumn(
+      'claims',
+      'speaker_name',
+      Sequelize.STRING,
+    ),
+    () => queryInterface.changeColumn(
+      'claims',
+      'speaker_affiliation',
+      Sequelize.STRING,
+    ),
+  ]),
+}

--- a/src/server/models/Claim.js
+++ b/src/server/models/Claim.js
@@ -3,7 +3,7 @@ module.exports = (sequelize, DataTypes) => {
     content: DataTypes.TEXT,
     claimedAt: DataTypes.DATE,
     canonicalUrl: DataTypes.STRING(1024),
-    scraperName: DataTypes.STRING(1024), // The scraper that generated this claim
+    scraperName: DataTypes.STRING, // The scraper that generated this claim
     source: DataTypes.STRING(1024),
     speakerName: DataTypes.STRING(1024),
     speakerAffiliation: DataTypes.STRING(1024),


### PR DESCRIPTION
This commit adds a migration to change the length of three `claims` table columns and modifies one `Claim` model attribute definitions to match the existing column (which was, incidentally, more correct).

Previously, we had a mismatch between our Sequelize model definition for Claims and the actual table structure. (That this is possible belies a bit of a problem in Sequelize itself, but I digress.) Four of the fields were defined as 1024 characters long in the model, but used the default 255-character length in their original migrations.

One of those fields, `scraper_name`, didn’t actually need to be 1024 anyway, so this changes the model definition. The other three could arguably fit into less than 1024 in many cases (especially `source`), but there’s no harm in making them long enough for edge cases.

**You will need to run migrations after merging this change.**

Resolves #253
