### PR TITLE
Save Twitter claims using preferred display name

### DIFF
--- a/src/server/models/TwitterAccount.js
+++ b/src/server/models/TwitterAccount.js
@@ -8,6 +8,17 @@ module.exports = (sequelize, DataTypes) => {
     isActive: DataTypes.BOOLEAN,
   }, {})
 
+  TwitterAccount.getByScreenNames = async screenNames => (TwitterAccount.findAll({
+    where: {
+      screenName: {
+        [Sequelize.Op.in]: screenNames,
+      },
+    },
+    order: [['createdAt', 'DESC']],
+  }))
+
+  TwitterAccount.getByScreenName = async screenName => TwitterAccount.getByScreenNames([screenName])
+
   TwitterAccount.getActive = async () => TwitterAccount.findAll({
     where: {
       isActive: true,

--- a/src/server/utils/__test__/index.test.js
+++ b/src/server/utils/__test__/index.test.js
@@ -3,6 +3,7 @@ import {
   isDevelopmentEnv,
   isProductionEnv,
   squish,
+  hasVisibleContent,
 } from '..'
 
 describe('utils/index', () => {
@@ -24,6 +25,17 @@ describe('utils/index', () => {
   describe('#squish', () => {
     it('Should replace all whitespace with single spaces', () => {
       expect(squish('Too  much   space.\nAmiright?')).toBe('Too much space. Amiright?')
+    })
+  })
+  describe('#hasVisibleContent', () => {
+    it('Should accept strings with non-whitespace content', () => {
+      expect(hasVisibleContent('Hello')).toBe(true)
+      expect(hasVisibleContent(' Hello ')).toBe(true)
+    })
+    it('Should reject strings without non-whitespace content', () => {
+      expect(hasVisibleContent()).toBe(false)
+      expect(hasVisibleContent('')).toBe(false)
+      expect(hasVisibleContent(' ')).toBe(false)
     })
   })
 })

--- a/src/server/utils/__test__/twitter.test.js
+++ b/src/server/utils/__test__/twitter.test.js
@@ -8,7 +8,18 @@ import {
   getSourceFromTweet,
   getTextFromTweet,
   getSpeakerAffiliationFromTweet,
+  getScreenNameHash,
+  getBestName,
+  getScreenNamesFromStatements,
+  normalizeStatementSpeaker,
 } from '../twitter'
+
+import {
+  statement,
+  statements,
+  normalizedStatement,
+  screenNameHashes,
+} from './twitterTestData'
 
 const exampleTweet = {
   id_str: '12345',
@@ -101,5 +112,34 @@ describe('getSpeakerAffiliationFromTweet', () => {
   it('Should pull the user description from a tweet', () => {
     expect(getSpeakerAffiliationFromTweet(exampleTweet))
       .toEqual(exampleTweet.user.description)
+  })
+})
+describe('getScreenNameHash', () => {
+  it('Should correctly hash screen names', () => {
+    screenNameHashes.forEach((screenName) => {
+      expect(getScreenNameHash(screenName.unhashed)).toEqual(screenName.hashed)
+    })
+  })
+})
+describe('getBestName', () => {
+  it('Should choose the best name of the bunch', () => {
+    expect(getBestName('John', 'Paul')).toEqual('Paul')
+    expect(getBestName('John', '')).toEqual('John')
+    expect(getBestName('John')).toEqual('John')
+  })
+})
+describe('getScreenNamesFromStatements', () => {
+  it('Should extract screen names from array of statements', () => {
+    expect(getScreenNamesFromStatements(statements)).toEqual(['reefdog'])
+  })
+})
+describe('normalizeStatementSpeaker', () => {
+  it('Should apply valid display name to speaker', () => {
+    expect(normalizeStatementSpeaker(statement, {
+      reefdog: 'Justin Reese',
+    })).toEqual(normalizedStatement)
+  })
+  it('Should not apply invalid display name to speaker', () => {
+    expect(normalizeStatementSpeaker(statement, '')).toEqual(statement)
   })
 })

--- a/src/server/utils/__test__/twitterTestData.js
+++ b/src/server/utils/__test__/twitterTestData.js
@@ -1,0 +1,24 @@
+export const statement = {
+  speaker: {
+    name: 'justin spooky reese',
+    affiliation: 'BIFFUD',
+  },
+  source: 'reefdog',
+  text: 'Booooffud!',
+}
+export const statements = [statement]
+
+export const normalizedStatement = Object.assign({}, statement, {
+  speaker: {
+    ...statement.speaker,
+    name: 'Justin Reese',
+  },
+})
+export const normalizedStatements = [normalizedStatement]
+
+export const screenNameHashes = [
+  {
+    unhashed: 'JohnSmith',
+    hashed: 'johnsmith',
+  },
+]

--- a/src/server/utils/index.js
+++ b/src/server/utils/index.js
@@ -32,3 +32,11 @@ export const runAsyncSequence = async (sequence, seed) => sequence.reduce(
  * @return {String}        The string with all whitespace sequences collapsed to single spaces
  */
 export const squish = string => string.replace(/\s+/g, ' ')
+
+/**
+ * Validates that the string has non-whitespace content.
+ *
+ * @param  {String} text The text you are curious about, o curious one
+ * @return {Boolean}     True if it has non-whitespace content, else false
+ */
+export const hasVisibleContent = text => !!text && text.replace(/\s/g, '').length > 0

--- a/src/server/utils/twitter.js
+++ b/src/server/utils/twitter.js
@@ -1,5 +1,10 @@
 import querystring from 'querystring'
 
+import { hasVisibleContent } from '.'
+import models from '../models'
+
+const { TwitterAccount } = models
+
 export const isTwitterScreenName = screenName => /^@?(\w){1,15}$/.test(screenName)
 
 export const getTwitterApiUrlForUserTimeline = (screenName) => {
@@ -35,3 +40,120 @@ export const extractStatementsFromTweets = tweets => tweets.map(tweet => ({
   canonicalUrl: getCanonicalUrlFromTweet(tweet),
   claimedAt: getTimestampFromTweet(tweet),
 }))
+
+/**
+ * Converts a screen name to a form that can reliably be used as a dict key.
+ *
+ * @param  {String} screenName The screen name you want to hash
+ * @return {String}            The screen name hash
+ */
+export const getScreenNameHash = screenName => screenName.toLowerCase()
+
+/**
+ * Returns the better of two name options.
+ *
+ * For Twitter, the `a` name will be the name scraped from the API, while the `b` name will be the
+ * name we've stored as "preferred" for that account. We don't do any fancy heuristics here,
+ * trusting in human intent. All we really do is make sure the preferred name isn't empty.
+ *
+ * @param  {String} a The default name
+ * @param  {String} b The candidate name for improvement
+ * @return {String}    The best name
+ */
+export const getBestName = (a, b) => (
+  hasVisibleContent(b) ? b : a
+)
+
+/**
+ * Given an array of statements, returns an array of screen names.
+ *
+ * @param  {Array<Statement>} statements An array of statements from which to pluck the screen name
+ * @return {Array<String>}               An array of screen names
+ */
+export const getScreenNamesFromStatements = statements => statements
+  .map(statement => statement.source)
+
+/**
+ * An accumulator function used by `reduce()` to extract an account's preferred display name and
+ * add it to the accumulator.
+ *
+ * @param  {Object}         displayNamesByScreenName A dict of display names keyed by screen name
+ * @param  {TwitterAccount} account                  The Twitter account we're adding to the dict
+ * @return {Object}                                  The dict, with the account added
+ */
+const applyDisplayNameToDict = (displayNamesByScreenName, account) => {
+  const {
+    screenName,
+    preferredDisplayName,
+  } = account
+  return Object.assign({}, displayNamesByScreenName, {
+    [getScreenNameHash(screenName)]: preferredDisplayName,
+  })
+}
+
+/**
+ * Given an array of screen names, looks up the preferred display names from the database and
+ * returns a dict mapping screen names to display name.
+ *
+ * Note that (1) this requires calling the database so it is an async functionm and (2) the dict
+ * that this returns uses screen name hashes as keys, so be sure to hash screen names through
+ * `getScreenNameHash()` when accessing the dict values that this function returns.
+ *
+ * @param  {Array<String>} screenNames An array of screen names
+ * @return {Promise<Object>}           When the Promise resolves, returns a dict mapping screen
+ *                                     names to display names
+ */
+export const getDisplayNamesForScreenNames = async screenNames => TwitterAccount
+  .getByScreenNames(screenNames)
+  .then(accounts => accounts.reduce(applyDisplayNameToDict, {}))
+
+/**
+ * Modifies the given statement with a normalized speaker name, using a collection of preferred
+ * display names (keyed by screen name).
+ *
+ * This function requires the entire statement as input since it relies on `statement.source` for
+ * display name lookup.
+ *
+ * Design caveat: Arguably, it could receive a statement but only return a speaker, but that
+ * version felt unintuitive and less legible than a statement in / statement out design.
+ *
+ * @param  {Statement} statement                The statement to apply a display name to
+ * @param  {Object}    displayNamesByScreenName A dict of display names keyed by screen name
+ * @return {Object}                             The statement, with speaker name normalized
+ */
+export const normalizeStatementSpeaker = (statement, displayNamesByScreenName) => {
+  const {
+    source,
+    speaker,
+    speaker: {
+      name: speakerName,
+    },
+  } = statement
+  const preferredDisplayName = displayNamesByScreenName[getScreenNameHash(source)]
+  const normalizedSpeakerName = getBestName(speakerName, preferredDisplayName)
+  return Object.assign({}, statement, {
+    speaker: {
+      ...speaker,
+      name: normalizedSpeakerName,
+    },
+  })
+}
+
+/**
+ * Given a list of statements, normalizes the speaker names for all the statements.
+ *
+ * In practice, this means looking up our preferred display names for each associated Twitter
+ * account from the database and applying them to each statement speaker.
+ *
+ * We want to await the database lookup, so this function is marked async.
+ *
+ * @param  {Array<Statement>} statements An array of statements whose speakers should be normalized
+ * @return {Promise<Array>}              A Promise that, when resolved, returns the array of
+ *                                       statements with normalized speaker names
+ */
+export const normalizeStatementSpeakers = async (statements) => {
+  const screenNames = getScreenNamesFromStatements(statements)
+  const displayNamesByScreenName = await getDisplayNamesForScreenNames(screenNames)
+  return statements
+    .map(statement => normalizeStatementSpeaker(statement, displayNamesByScreenName))
+}

--- a/src/server/workers/scrapers/TwitterAccountStatementScraper.js
+++ b/src/server/workers/scrapers/TwitterAccountStatementScraper.js
@@ -1,12 +1,15 @@
 import OAuth from 'oauth'
+
 import config from '../../config'
 import { STATEMENT_SCRAPER_NAMES } from './constants'
 
+import { runAsyncSequence } from '../../utils'
 import {
   isTwitterScreenName,
   getTwitterApiUrlForUserTimeline,
   parseJsonIntoTweets,
   extractStatementsFromTweets,
+  normalizeStatementSpeakers,
 } from '../../utils/twitter'
 
 import AbstractStatementScraper from './AbstractStatementScraper'
@@ -44,20 +47,11 @@ class TwitterAccountStatementScraper extends AbstractStatementScraper {
     )
   }
 
-  extractStatementsFromTwitterApiResponse = (responseString) => {
-    const stepSequence = [
-      parseJsonIntoTweets,
-      extractStatementsFromTweets,
-    ] // Note that order does matter here
-
-    const statements = stepSequence.reduce((string, fn) => fn(string), responseString)
-    return statements
-  }
-
-  statementScrapeHandler = (responseString) => {
-    const statements = this.extractStatementsFromTwitterApiResponse(responseString)
-    return statements
-  }
+  statementScrapeHandler = async responseString => runAsyncSequence([
+    parseJsonIntoTweets,
+    extractStatementsFromTweets,
+    normalizeStatementSpeakers,
+  ], responseString)
 }
 
 export default TwitterAccountStatementScraper


### PR DESCRIPTION
By design, we intended to associated Twitter claims with the human-curated “preferred display name” stored in `TwitterAccount.preferredDisplayName`. Previously, though, we were just using the Twitter account’s scraped name.

Now, we actually use the preferred display name from the database, if it exists and is non-empty.

Resolves #249

Note: because we introduced new references to `speaker.name`, either this branch or #268 will need adjusting based on who gets merged first.