### PR TITLE
Support `Claim.claimedAt` and use it for Twitter

### DIFF
--- a/src/server/newsletters/NationalNewsletter.js
+++ b/src/server/newsletters/NationalNewsletter.js
@@ -53,7 +53,7 @@ class NationalNewsletter extends AbstractNewsletter {
   generateQueryParams = where => ({
     where: {
       ...where,
-      createdAt: {
+      claimedAt: {
         [Sequelize.Op.gte]: dayjs().startOf('hour').subtract(1, 'day').format(),
         [Sequelize.Op.lt]: dayjs().startOf('hour').format(),
       },

--- a/src/server/newsletters/NorthCarolinaNewsletter.js
+++ b/src/server/newsletters/NorthCarolinaNewsletter.js
@@ -45,7 +45,7 @@ class NorthCarolinaNewsletter extends AbstractNewsletter {
   generateQueryParams = where => ({
     where: {
       ...where,
-      createdAt: {
+      claimedAt: {
         [Sequelize.Op.gte]: dayjs().startOf('hour').subtract(1, 'day').format(),
         [Sequelize.Op.lt]: dayjs().startOf('hour').format(),
       },

--- a/src/server/queues/claimBusterClaimDetectorQueue/claimBusterClaimDetectorJobProcessor.js
+++ b/src/server/queues/claimBusterClaimDetectorQueue/claimBusterClaimDetectorJobProcessor.js
@@ -12,6 +12,7 @@ const saveClaim = async claim => Claim.create({
   canonicalUrl: claim.canonicalUrl,
   scraperName: claim.scraperName,
   source: claim.source,
+  claimedAt: claim.claimedAt,
 })
 
 export default async (job) => {

--- a/src/server/utils/twitter.js
+++ b/src/server/utils/twitter.js
@@ -23,6 +23,8 @@ export const getTextFromTweet = tweet => tweet.full_text
 
 export const getSpeakerAffiliationFromTweet = tweet => tweet.user.description
 
+export const getTimestampFromTweet = tweet => tweet.created_at
+
 export const extractStatementsFromTweets = tweets => tweets.map(tweet => ({
   speaker: {
     name: getSpeakerNameFromTweet(tweet),
@@ -31,4 +33,5 @@ export const extractStatementsFromTweets = tweets => tweets.map(tweet => ({
   text: getTextFromTweet(tweet),
   source: getSourceFromTweet(tweet),
   canonicalUrl: getCanonicalUrlFromTweet(tweet),
+  claimedAt: getTimestampFromTweet(tweet),
 }))

--- a/src/server/workers/claimDetectors/ClaimBusterClaimDetector.js
+++ b/src/server/workers/claimDetectors/ClaimBusterClaimDetector.js
@@ -16,6 +16,7 @@ class ClaimBusterClaimDetector {
       canonicalUrl,
       scraperName,
       source,
+      claimedAt,
     } = this.statement
     return rp
       .post({
@@ -36,6 +37,7 @@ class ClaimBusterClaimDetector {
           canonicalUrl,
           scraperName,
           source,
+          claimedAt,
         })))
   }
 }

--- a/src/server/workers/scrapers/AbstractStatementScraper.js
+++ b/src/server/workers/scrapers/AbstractStatementScraper.js
@@ -1,3 +1,5 @@
+import dayjs from 'dayjs'
+
 import AbstractScraper from './AbstractScraper'
 import models from '../../models'
 import {
@@ -95,13 +97,16 @@ class AbstractStatementScraper extends AbstractScraper {
    * @param {Object[]} statements The statements that have been scraped
    * @return {Object[]}           Those same statements with additional schema properties added
    */
-  addSchemaPropertiesToStatements = statements => statements
-    .map(statement => ({
+  addSchemaPropertiesToStatements = (statements) => {
+    const timestamp = dayjs().format()
+    return statements.map(statement => ({
       ...statement,
       scraperName: this.getScraperName(),
       canonicalUrl: statement.canonicalUrl || this.getStatementCanonicalUrl(statement),
       source: statement.source || this.getStatementSource(statement),
+      claimedAt: statement.claimedAt || timestamp,
     }))
+  }
 
   /**
    * Statements have some properties that are not part of their schema but are


### PR DESCRIPTION
We’ve had a `Claim.claimedAt` attribute, but haven’t been using it. Instead, we've been using `createdAt` as a proxy.

This PR adds the infrastructure for scrapers to populate `Claim.claimedAt`; modifies newsletters to query by `claimedAt` rather than `createdAt`; and updates the Twitter scraper to populate the field. It will take longer to reliably scrape `claimedAt` for CNN (see #100), so those will continue to fall back to the scrape time instead.

After deploying, we should run `UPDATE claims SET claimed_at = created_at WHERE claimed_at IS NULL` for backwards-compatibility.

Affects #100
Resolves #258
