### PR TITLE
Remove jobs on completion by default

### DIFF
--- a/src/server/queues/AbstractQueueFactory.js
+++ b/src/server/queues/AbstractQueueFactory.js
@@ -37,6 +37,7 @@ class AbstractQueueFactory {
       {
         defaultJobOptions: {
           removeOnComplete: true,
+          removeOnFail: true,
         },
       },
     )

--- a/src/server/queues/AbstractQueueFactory.js
+++ b/src/server/queues/AbstractQueueFactory.js
@@ -34,6 +34,11 @@ class AbstractQueueFactory {
     const queue = new Queue(
       this.getQueueName(),
       config.REDIS_URL,
+      {
+        defaultJobOptions: {
+          removeOnComplete: true,
+        },
+      },
     )
     queue.on('error', error => logger.error(error))
     queue.on('failed', (job, error) => logger.warn(error))


### PR DESCRIPTION
When the scrapers were running we were slowly accumulating jobs in redis which over time essentially served as a memory leak.  This updates our queues to default to deleting jobs upon completion.

Resolves #261