### PR TITLE
Add active/inactive concept to TwitterAccount

### DIFF
--- a/src/server/migrations/20191001161648-add-is-active-to-twitter-accounts.js
+++ b/src/server/migrations/20191001161648-add-is-active-to-twitter-accounts.js
@@ -1,0 +1,18 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface
+    .addColumn(
+      'twitter_accounts',
+      'is_active',
+      {
+        type: Sequelize.BOOLEAN,
+        defaultValue: true,
+        allowNull: false,
+      },
+    ),
+
+  down: queryInterface => queryInterface
+    .removeColumn(
+      'twitter_accounts',
+      'is_active',
+    ),
+}

--- a/src/server/models/TwitterAccount.js
+++ b/src/server/models/TwitterAccount.js
@@ -5,19 +5,28 @@ module.exports = (sequelize, DataTypes) => {
     screenName: DataTypes.STRING(128),
     preferredDisplayName: DataTypes.STRING(512),
     listName: DataTypes.STRING(128),
+    isActive: DataTypes.BOOLEAN,
   }, {})
 
-  TwitterAccount.getByListNames = async listNames => (
+  TwitterAccount.getActive = async () => TwitterAccount.findAll({
+    where: {
+      isActive: true,
+    },
+  })
+
+  TwitterAccount.getActiveByListNames = async listNames => (
     TwitterAccount.findAll({
       where: {
         listName: {
           [Sequelize.Op.in]: listNames,
         },
+        isActive: true,
       },
     })
   )
 
-  TwitterAccount.getByListName = async listName => TwitterAccount.getByListNames([listName])
+  TwitterAccount.getActiveByListName = async listName => TwitterAccount
+    .getActiveByListNames([listName])
 
   return TwitterAccount
 }

--- a/src/server/queues/twitterScrapeInitiationQueue/twitterScrapeInitiationJobProcessor.js
+++ b/src/server/queues/twitterScrapeInitiationQueue/twitterScrapeInitiationJobProcessor.js
@@ -12,10 +12,10 @@ const scrapeTwitterAccount = twitterAccount => twitterAccountStatementScraperQue
   screenName: twitterAccount.screenName,
 })
 
-const getAllTwitterAccounts = () => TwitterAccount.findAll()
+const getActiveTwitterAccounts = () => TwitterAccount.getActive()
 
 export default async () => {
-  const twitterAccounts = await getAllTwitterAccounts()
+  const twitterAccounts = await getActiveTwitterAccounts()
   twitterAccounts.forEach(scrapeTwitterAccount)
   return twitterAccounts
 }

--- a/src/server/utils/newsletters.js
+++ b/src/server/utils/newsletters.js
@@ -51,7 +51,7 @@ export const guardMailingList = list => ((isProductionEnv() || isInternalMailing
  * @return {Array}           The screen names for that list
  */
 export const getTwitterScreenNamesByListName = async listName => (
-  TwitterAccount.getByListName(listName)
+  TwitterAccount.getActiveByListName(listName)
     .then(accounts => accounts.map(account => account.screenName))
 )
 
@@ -63,7 +63,7 @@ export const getTwitterScreenNamesByListName = async listName => (
  *                                   object keyed by list name
  */
 export const getTwitterScreenNamesByListNames = async listNames => (
-  TwitterAccount.getByListNames(listNames)
+  TwitterAccount.getActiveByListNames(listNames)
     .then(accounts => accounts.reduce((lists, account) => {
       if (hasKey(lists, account.listName)) {
         lists[account.listName].push(account.screenName)


### PR DESCRIPTION
We periodically update the Twitter accounts we want to scrape. Rather than deleting them from the database, we want to be able to deactivate and reactivate them, and we want the scrape and newsletter composition queries to scope by active state.

This PR adds the fundamental concept of `TwitterAccount.isActive`, including its database migration (and column configuration) and scoping relevant queries.

This lays the foundation for #255 but does not resolve it because it doesn't provide any functions or examples for changing the active state.

Note: you must run migrations after merging this PR.