### PR TITLE
Add more robust TESTING.md documentation

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -6,15 +6,68 @@ We aspire to have a full-blown robust unit and integration test suite, but for n
 
 Still: if you write code that can be tested, please ensure all PRs include tests of that code.
 
-## Generating tests for the CNN scraper
+## Test organization
+
+### Unit Tests
+Unit tests should be placed in a __test__/ directory that lives at the same level of the file being tested.  Each file should have a parallel `.test.js`
+
+For example: 
+
+```
+|- /src
+|  |- __test__
+|  |  |- sillyHat.test.js
+|  |- sillyHat.js
+```
+
+### Integration Tests
+
+Since integration tests often involve multiple files, they should live in a common `src/tests` directory.  We have not yet written any integration tests so this documentation should be updated when that occurs.
+
+### Test Data
+
+Test data should be placed in a file that is sibling to the test file and have the `TestData.js` prefix.
+
+For example: 
+
+```
+|- /src
+|  |- __test__
+|  |  |- sillyHat.test.js
+|  |  |- sillyHatTestData.js
+|  |- sillyHat.js
+```
+
+### Test Suite Data
+
+Regression test suites, where applicable, should store regression suite data in a `data` directory that is sibling to the test file, inside of a folder that is named after the file being tested.  The data itself should be named according to the needs of the test suite.
+
+For example: 
+
+```
+|- /src
+|  |- __test__
+|  |  |- data
+|  |  |  |- sillyHat
+|  |  |  |  |- 1
+|  |  |  |  |  |- methodName.js
+|  |  |- sillyHat.test.js
+|  |- sillyHat.js
+```
+
+## Specialized Documentation
+
+Below is instruction on writing test for specific components of the system.
+
+### Generating tests for the CNN scraper
 
 Since the CNN transcript scraper pipeline is fairly complex, we've created a tool to generate new unit tests for each step of the pipeline whenever we find a transcript that causes trouble.
 
-### To create a test suite for a transcript that is being processed properly:
+#### To create a test suite for a transcript that is being processed properly:
 
 1. Run `yarn generate:test:cnn -u {FULL_TRANSCRIPT_URL_HERE}`
 
-### To debug and correct the pipeline for a transcript that is not being processed properly:
+#### To debug and correct the pipeline for a transcript that is not being processed properly:
 
 1. Create a test suite (see above)
 2. Open up the new test suite directory in `/src/server/utils/__test__/data/cnn`.  The suite directories reflect the suite index.  Indices are sequential and auto increment, so the new suite will be in the highest-numbered directory.


### PR DESCRIPTION
This attempts to capture the practices we have invoked so far.

There are still some areas that are not fleshed out (e.g. integration testing instructions) but there is no need to invent that until we actually begin to write integration tests.

Resolves #47