### PR TITLE
Add google spreadsheet scraper

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "bull": "^3.9.1",
     "cheerio": "^1.0.0-rc.3",
+    "csv-parse": "^4.8.2",
     "dayjs": "^1.8.14",
     "dotenv": "^8.0.0",
     "handlebars": "^4.1.2",

--- a/src/server/utils/__test__/google.test.js
+++ b/src/server/utils/__test__/google.test.js
@@ -1,0 +1,16 @@
+import {
+  getSpreadsheetCsvUrl,
+  parseCsvString,
+} from '../google'
+
+describe('getSpreadsheetCsvUrl', () => {
+  it('Should return a google URL for an ID', () => {
+    expect(getSpreadsheetCsvUrl('a-google-document-id'))
+      .toBe('https://docs.google.com/spreadsheets/d/a-google-document-id/export?format=csv')
+  })
+})
+
+describe('parseCsvString', () => {
+  test('Should parse a CSV from a string', () => parseCsvString('1,2,3\na,b,c').then(data => expect(data)
+    .toEqual([['1', '2', '3'], ['a', 'b', 'c']])))
+})

--- a/src/server/utils/google.js
+++ b/src/server/utils/google.js
@@ -1,0 +1,11 @@
+import parse from 'csv-parse'
+
+export const getSpreadsheetCsvUrl = spreadsheetId => `https://docs.google.com/spreadsheets/d/${spreadsheetId}/export?format=csv`
+
+export const parseCsvString = async googleCsvString => new Promise((resolve, reject) => {
+  const output = []
+  parse(googleCsvString)
+    .on('data', record => output.push(record))
+    .on('error', error => reject(error))
+    .on('end', () => resolve(output))
+})

--- a/src/server/workers/scrapers/GoogleSpreadsheetScraper.js
+++ b/src/server/workers/scrapers/GoogleSpreadsheetScraper.js
@@ -1,0 +1,18 @@
+import AbstractScraper from './AbstractScraper'
+import { STATEMENT_SCRAPER_NAMES } from './constants'
+import {
+  getSpreadsheetCsvUrl,
+  parseCsvString,
+} from '../../utils/google'
+
+class GoogleSpreadsheetScraper extends AbstractScraper {
+  constructor(spreadsheetId) {
+    super(getSpreadsheetCsvUrl(spreadsheetId))
+  }
+
+  getScraperName = () => STATEMENT_SCRAPER_NAMES.GOOGLE_SPREADSHEET
+
+  scrapeHandler = async responseString => parseCsvString(responseString)
+}
+
+export default GoogleSpreadsheetScraper

--- a/src/server/workers/scrapers/constants.js
+++ b/src/server/workers/scrapers/constants.js
@@ -10,6 +10,7 @@ export const STATEMENT_SCRAPER_NAMES = {
 
 export const SCRAPER_NAMES = {
   GENERIC: 'generic',
+  GOOGLE_SPREADSHEET: 'googleSpreadsheet',
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2587,6 +2587,11 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
+csv-parse@^4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.8.2.tgz#c717cc8d87f619dbd556d5a15222a83b6d7a6d06"
+  integrity sha512-WfYwyJepTbjS5jWAWpVskOJ8Z10231HaFw6qJhSjGrpfMPf3yuoRohlasYsP/6/3YgTQcvZpTvoUo37eaei9Fw==
+
 d@1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"


### PR DESCRIPTION
This creates the ability to scrape a google spreadsheet, this worker will be used in the queues created for #229 and #280 since google spreadsheets are the initial mechanism for updating things like twitter and priority speaker lists.

This creates a new dependency on a utility package called [csv-parse](https://www.npmjs.com/package/csv-parse) (which I think is necessary because please do not make me write my own CSV parser.)