### PR TITLE
Update Claimbuster API endpoint

### DIFF
--- a/src/server/constants.js
+++ b/src/server/constants.js
@@ -21,4 +21,4 @@ export const TWITTER_LIST_NAMES = {
 
 export const CLAIMBUSTER_THRESHHOLD = 0.5
 
-export const CLAIMBUSTER_API_ROOT_URL = 'https://idir.uta.edu/claimbuster-dev/api/v1'
+export const CLAIMBUSTER_API_ROOT_URL = 'https://idir.uta.edu/claimbuster/api/v1'


### PR DESCRIPTION
Previously, Claimbuster only offered the dev version of the API.

They recently added a production version and requested we switch to it.

Resolves #290