### PR TITLE
Update claimbuster API endpoint

### DIFF
--- a/src/server/constants.js
+++ b/src/server/constants.js
@@ -21,4 +21,4 @@ export const TWITTER_LIST_NAMES = {
 
 export const CLAIMBUSTER_THRESHHOLD = 0.5
 
-export const CLAIMBUSTER_API_ROOT_URL = 'https://idir.uta.edu/claimbuster-dev/api/v1'
+export const CLAIMBUSTER_API_ROOT_URL = 'https://idir.uta.edu/claimbuster/api/v1'


### PR DESCRIPTION
We're going to be using a new ClaimBuster API endpoint, now that they have a production version.

Resolves #290