### PR TITLE
Repair newsletter display of claim speaker

### DIFF
--- a/src/server/newsletters/templates/national.hbs
+++ b/src/server/newsletters/templates/national.hbs
@@ -10,7 +10,7 @@
         <div class="claim__metadata">
           <a href="{{canonicalUrl}}" class="claim__permalink">
             <cite class="claim__speaker">
-              {{speakerName}}
+              {{speakerNormalizedName}}
             </cite>
             {{#if source}}<span class="claim__source">on {{ source }}</span>{{/if}}
             <span class="claim__platform">({{convertScraperNameToPlatformName scraperName}})</span></a>:
@@ -33,7 +33,7 @@
         <div class="claim__metadata">
           <a href="{{canonicalUrl}}" class="claim__permalink">
             <cite class="claim__speaker">
-              {{speakerName}}
+              {{speakerNormalizedName}}
             </cite>
             <span class="claim__platform">({{convertScraperNameToPlatformName scraperName}})</span></a>:
         </div>

--- a/src/server/newsletters/templates/nationalText.hbs
+++ b/src/server/newsletters/templates/nationalText.hbs
@@ -5,7 +5,7 @@
 📺 TV CLAIMS 📺
 {{#each claims.TV}}
 
-{{speakerName}}{{#if source}} on {{ source }}{{/if}} ({{convertScraperNameToPlatformName scraperName}}):
+{{speakerNormalizedName}}{{#if source}} on {{ source }}{{/if}} ({{convertScraperNameToPlatformName scraperName}}):
 {{ content }}
 — {{canonicalUrl}}
 {{else}}
@@ -17,7 +17,7 @@ Looks like we didn't see any TV claims over the past day. 🤔🤔🤔
 🎭 SOCIAL MEDIA CLAIMS 🎭
 {{#each claims.SOCIAL}}
 
-{{speakerName}} ({{convertScraperNameToPlatformName scraperName}}):
+{{speakerNormalizedName}} ({{convertScraperNameToPlatformName scraperName}}):
 {{ content }}
 — {{canonicalUrl}}
 {{else}}

--- a/src/server/newsletters/templates/northCarolina.hbs
+++ b/src/server/newsletters/templates/northCarolina.hbs
@@ -10,7 +10,7 @@
         <div class="claim__metadata">
           <a href="{{canonicalUrl}}" class="claim__permalink">
             <cite class="claim__speaker">
-              {{speakerName}}
+              {{speakerNormalizedName}}
             </cite>
             <span class="claim__platform">({{convertScraperNameToPlatformName scraperName}})</span></a>:
         </div>

--- a/src/server/newsletters/templates/northCarolinaText.hbs
+++ b/src/server/newsletters/templates/northCarolinaText.hbs
@@ -5,7 +5,7 @@
 🎭 SOCIAL MEDIA CLAIMS 🎭
 {{#each claims.SOCIAL}}
 
-{{speakerName}} ({{convertScraperNameToPlatformName scraperName}}):
+{{speakerNormalizedName}} ({{convertScraperNameToPlatformName scraperName}}):
 {{ content }}
 — {{canonicalUrl}}
 {{else}}


### PR DESCRIPTION
In #268 and #294, we updated the Claim model to split `speakerName` into two fields, (`speakerExtractedName` and `speakerNormalizedName`, with the latter intended for display) but didn’t flow this change down to the newsletter.

This change correctly displays the normalized name in the newsletter.

Resolves #297
