### PR TITLE
Fix Twitter scraper to normalize speaker name

### DIFF
--- a/src/server/utils/__test__/twitterTestData.js
+++ b/src/server/utils/__test__/twitterTestData.js
@@ -11,7 +11,8 @@ export const tweets = [tweet]
 
 export const extractedStatement = {
   speaker: {
-    name: tweet.user.name,
+    extractedName: tweet.user.name,
+    normalizedName: tweet.user.name,
     affiliation: tweet.user.description,
   },
   text: tweet.full_text,
@@ -22,7 +23,8 @@ export const extractedStatements = [extractedStatement]
 
 export const statement = {
   speaker: {
-    name: 'justin spooky reese',
+    extractedName: 'justin spooky reese',
+    normalizedName: 'justin spooky reese',
     affiliation: 'BIFFUD',
   },
   source: 'reefdog',
@@ -33,7 +35,7 @@ export const statements = [statement]
 export const normalizedStatement = Object.assign({}, statement, {
   speaker: {
     ...statement.speaker,
-    name: 'Justin Reese',
+    normalizedName: 'Justin Reese',
   },
 })
 export const normalizedStatements = [normalizedStatement]

--- a/src/server/utils/twitter.js
+++ b/src/server/utils/twitter.js
@@ -32,7 +32,8 @@ export const getTimestampFromTweet = tweet => tweet.created_at
 
 export const extractStatementsFromTweets = tweets => tweets.map(tweet => ({
   speaker: {
-    name: getSpeakerNameFromTweet(tweet),
+    extractedName: getSpeakerNameFromTweet(tweet),
+    normalizedName: getSpeakerNameFromTweet(tweet),
     affiliation: getSpeakerAffiliationFromTweet(tweet),
   },
   text: getTextFromTweet(tweet),
@@ -126,7 +127,7 @@ export const normalizeStatementSpeaker = (statement, displayNamesByScreenName) =
     source,
     speaker,
     speaker: {
-      name: speakerName,
+      extractedName: speakerName,
     },
   } = statement
   const preferredDisplayName = displayNamesByScreenName[getScreenNameHash(source)]
@@ -134,7 +135,7 @@ export const normalizeStatementSpeaker = (statement, displayNamesByScreenName) =
   return Object.assign({}, statement, {
     speaker: {
       ...speaker,
-      name: normalizedSpeakerName,
+      normalizedName: normalizedSpeakerName,
     },
   })
 }


### PR DESCRIPTION
In #268 and #294, we updated the Claim model to split `speakerName` into two fields, (`speakerExtractedName` and `speakerNormalizedName`). Our speaker name normalizers are supposed to store the original extracted name in both fields, then normalize the name and store it in `speakerNormalizedName`.

We made this change for CNN, but not for Twitter. This change covers Twitter.

Resolves #298