### PR TITLE
Add tests for ClaimBusterClaimDetector

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.12.4",
     "jest": "^24.8.0",
+    "nock": "^11.7.2",
     "nodemon": "^1.19.0",
     "parcel": "^1.12.4",
     "sequelize-cli": "^5.5.0"

--- a/src/server/workers/claimDetectors/__test__/ClaimBusterClaimDetector.test.js
+++ b/src/server/workers/claimDetectors/__test__/ClaimBusterClaimDetector.test.js
@@ -1,0 +1,68 @@
+import nock from 'nock'
+
+import ClaimBusterClaimDetector from '../ClaimBusterClaimDetector'
+import config from '../../../config'
+import {
+  CLAIMBUSTER_API_ROOT_URL,
+  CLAIMBUSTER_THRESHHOLD,
+} from '../../../constants'
+
+/**
+ * Converts a list of sentence / score tuples into a mocked claimbuster API response.
+ * @param  {Array[Array[String, Integer]]} An array of sentence / score pairs.
+ * @return {Object}                 The mocked API response.
+ */
+const mockClaimBusterResponse = scoredSentences => ({
+  claim: scoredSentences.map(scoredSentence => scoredSentence[0]).join(' '),
+  origin: '',
+  results: scoredSentences.map((scoredSentence, i) => ({
+    score: scoredSentence[1],
+    index: i,
+    text: scoredSentence[0],
+  })),
+})
+
+const countScoresAboveClaimBusterThreshhold = scoredSentences => scoredSentences.reduce(
+  (total, scoredSentence) => total + (scoredSentence[1] > CLAIMBUSTER_THRESHHOLD ? 1 : 0),
+  0,
+)
+
+describe('ClaimBusterClaimDetector', () => {
+  describe('getClaims', () => {
+    it('ClaimBuster API call should include an API key in the header', async () => {
+      nock(CLAIMBUSTER_API_ROOT_URL, {
+        reqheaders: {
+          'x-api-key': headerValue => headerValue === config.CLAIMBUSTER_API_KEY,
+        },
+      })
+        .post('/score/text/')
+        .reply(200, mockClaimBusterResponse([]))
+
+      const claimBusterClaimDetector = new ClaimBusterClaimDetector('')
+      await expect(claimBusterClaimDetector.getClaims())
+        .resolves
+        .not.toThrow()
+    })
+
+    it(`Should return only the claims that surpass the configured score threshhold (${CLAIMBUSTER_THRESHHOLD})`, async () => {
+      const scoredSentences = [
+        ['It would take 500 babies to eat 10 onions.', 0.7947227125364000],
+        ['How many onions could 1000 babies eat?', 0.2172498345395903],
+        ['Lets ensure at least one', CLAIMBUSTER_THRESHHOLD + 0.01],
+      ]
+      const totalClaimsAboveThreshhold = countScoresAboveClaimBusterThreshhold(scoredSentences)
+
+      nock(CLAIMBUSTER_API_ROOT_URL)
+        .post('/score/text/')
+        .reply(200, mockClaimBusterResponse(scoredSentences))
+
+      const claimBusterClaimDetector = new ClaimBusterClaimDetector(
+        'It would take 500 babies to eat 10 onions. How many onions could 1000 babies eat?',
+      )
+      const claims = await claimBusterClaimDetector.getClaims()
+
+      expect(Array.isArray(claims)).toBe(true)
+      expect(claims).toHaveLength(totalClaimsAboveThreshhold)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5022,7 +5022,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -5683,6 +5683,17 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+nock@^11.7.2:
+  version "11.7.2"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-11.7.2.tgz#4cee4fa838dc3635c074c5b3436bcdec7f7ee213"
+  integrity sha512-7swr5bL1xBZ5FctyubjxEVySXOSebyqcL7Vy1bx1nS9IUqQWj81cmKjVKJLr8fHhtzI1MV8nyCdENA/cGcY1+Q==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.13"
+    mkdirp "^0.5.0"
+    propagate "^2.0.0"
 
 node-addon-api@^1.6.0:
   version "1.7.1"
@@ -6953,6 +6964,11 @@ prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 proto-list@~1.2.1:
   version "1.2.4"


### PR DESCRIPTION
This is the first part of a push for adding tests to components.  It is not quite an integration test, but invokes more high level code than a simple unit test might.

To test the ClaimBusterClaimDetector we needed to mock ClaimBuster API responses.  We're using [`nock`](https://www.npmjs.com/package/nock) for this.

## How to test
This is not changing functionality, so testing simply involves invoking the tests:

`yarn test`

You'll have to `yarn install` before you can run tests.  Arguably you could just look at the CI outcome to know if the tests pass...