### PR TITLE
Set test urls to placeholder domains

### DIFF
--- a/src/server/utils/__test__/cnn.test.js
+++ b/src/server/utils/__test__/cnn.test.js
@@ -60,7 +60,7 @@ describe('utils/cnn', () => {
 
   describe('isTranscriptListUrl', () => {
     it('Should not improperly identify transcript list URLs', () => {
-      expect(isTranscriptListUrl('http://google.com'))
+      expect(isTranscriptListUrl('http://example.com/'))
         .toBe(false)
     })
     it('Should identify transcript list URLs', () => {
@@ -71,7 +71,7 @@ describe('utils/cnn', () => {
 
   describe('isTranscriptUrl', () => {
     it('Should not improperly identify transcript URLs', () => {
-      expect(isTranscriptUrl('http://google.com'))
+      expect(isTranscriptUrl('http://example.com/'))
         .toBe(false)
     })
     it('Should identify transcript list URLs', () => {
@@ -86,8 +86,8 @@ describe('utils/cnn', () => {
 
   describe('getFullCnnUrl', () => {
     it('Should not modify a complete URL', () => {
-      expect(getFullCnnUrl('http://google.com'))
-        .toBe('http://google.com')
+      expect(getFullCnnUrl('http://example.com/'))
+        .toBe('http://example.com/')
       expect(getFullCnnUrl('http://transcripts.cnn.com'))
         .toBe('http://transcripts.cnn.com')
     })

--- a/src/server/utils/__test__/crawler.test.js
+++ b/src/server/utils/__test__/crawler.test.js
@@ -5,19 +5,19 @@ import {
 
 describe('extractUrl', () => {
   it('Should extract URLs from anchor tags', () => {
-    expect(extractUrl('<a href="google.com"></a>'))
-      .toBe('google.com')
+    expect(extractUrl('<a href="example.com"></a>'))
+      .toBe('example.com')
   })
 })
 
 describe('extractUrls', () => {
   it('Should extract a single URLs from an anchor tag', () => {
-    expect(extractUrls('<a href="google.com"></a>'))
-      .toEqual(['google.com'])
+    expect(extractUrls('<a href="example.com"></a>'))
+      .toEqual(['example.com'])
   })
 
   it('Should extract multiple URLs from multiple anchor tags', () => {
-    expect(extractUrls('<a href="google.com"></a><a href="cnn.com"></a>'))
-      .toEqual(['google.com', 'cnn.com'])
+    expect(extractUrls('<a href="example.com"></a><a href="example.net"></a>'))
+      .toEqual(['example.com', 'example.net'])
   })
 })

--- a/src/server/utils/__test__/scraper.test.js
+++ b/src/server/utils/__test__/scraper.test.js
@@ -63,19 +63,19 @@ describe('getUniqueCanonicalUrls', () => {
   const statements = [
     {
       text: 'Hello world!',
-      canonicalUrl: 'https://pants.com',
+      canonicalUrl: 'https://example.com',
     },
     {
       text: 'Hello again world!',
-      canonicalUrl: 'https://pants.com',
+      canonicalUrl: 'https://example.com',
     },
     {
       text: 'Hello chicken!',
-      canonicalUrl: 'https://chicken.com',
+      canonicalUrl: 'https://example.net',
     },
   ]
   it('Should remove previously scraped statements', () => {
     expect(getUniqueCanonicalUrls(statements).sort())
-      .toEqual(['https://pants.com', 'https://chicken.com'].sort())
+      .toEqual(['https://example.com', 'https://example.net'].sort())
   })
 })

--- a/src/server/workers/crawlers/HelloWorldCrawler.js
+++ b/src/server/workers/crawlers/HelloWorldCrawler.js
@@ -3,7 +3,7 @@ import { extractUrls } from '../../utils/crawler'
 
 class HelloWorldCrawler extends AbstractCrawler {
   constructor() {
-    super('https://google.com')
+    super('https://example.com')
   }
 
   crawlHandler = responseString => extractUrls(responseString)

--- a/src/server/workers/mailer/__test__/mailerTestData.js
+++ b/src/server/workers/mailer/__test__/mailerTestData.js
@@ -1,17 +1,17 @@
 export default {
   recipient: {
     valid: [
-      'test@test.com',
-      't@t.co',
-      'first+last@test.com',
-      'first.last@test.com',
-      'test@test.co.uk',
+      'test@example.com',
+      't@example.co',
+      'first+last@example.com',
+      'first.last@example.com',
+      'test@example.co.uk',
     ],
     invalid: [
-      '@test.com',
+      '@example.com',
       'test@',
       'test',
-      'test@test',
+      'test@example',
     ],
   },
   subject: {


### PR DESCRIPTION
This replaces test urls like google.com and pants.com with variations of example.com, example.net, etc. 

Resolves #207 