### PR TITLE
Add CNN crawler tests

### DIFF
--- a/src/server/workers/crawlers/CnnCrawlers/__test__/CnnTranscriptListCrawler.test.js
+++ b/src/server/workers/crawlers/CnnCrawlers/__test__/CnnTranscriptListCrawler.test.js
@@ -1,0 +1,21 @@
+import nock from 'nock'
+import fs from 'fs'
+import path from 'path'
+
+import CnnTranscriptListCrawler from '../CnnTranscriptListCrawler'
+
+describe('CnnTranscriptListCrawler', () => {
+  describe('run', () => {
+    it('CnnTranscriptListCrawler should return urls', async () => {
+      const portalMock = fs.readFileSync(path.resolve(__dirname, 'data/transcriptListMock.html'), 'utf8')
+      nock('http://transcripts.cnn.com')
+        .get('/TRANSCRIPTS/2020.01.21.html')
+        .reply(200, portalMock)
+
+      const cnnTranscriptListCrawler = new CnnTranscriptListCrawler('/TRANSCRIPTS/2020.01.21.html')
+      const urls = await cnnTranscriptListCrawler.run()
+      expect(Array.isArray(urls)).toBe(true)
+      expect(urls).toHaveLength(55)
+    })
+  })
+})

--- a/src/server/workers/crawlers/CnnCrawlers/__test__/CnnTranscriptPortalCrawler.test.js
+++ b/src/server/workers/crawlers/CnnCrawlers/__test__/CnnTranscriptPortalCrawler.test.js
@@ -1,0 +1,21 @@
+import nock from 'nock'
+import fs from 'fs'
+import path from 'path'
+
+import CnnTranscriptPortalCrawler from '../CnnTranscriptPortalCrawler'
+
+describe('CnnTranscriptPortalCrawler', () => {
+  describe('run', () => {
+    it('CnnTranscriptPortalCrawler should return urls', async () => {
+      const portalMock = fs.readFileSync(path.resolve(__dirname, 'data/portalMock.html'), 'utf8')
+      nock('http://transcripts.cnn.com')
+        .get('/TRANSCRIPTS/')
+        .reply(200, portalMock)
+
+      const cnnTranscriptPortalCrawler = new CnnTranscriptPortalCrawler()
+      const urls = await cnnTranscriptPortalCrawler.run()
+      expect(Array.isArray(urls)).toBe(true)
+      expect(urls).toHaveLength(46)
+    })
+  })
+})

--- a/src/server/workers/crawlers/CnnCrawlers/__test__/data/portalMock.html
+++ b/src/server/workers/crawlers/CnnCrawlers/__test__/data/portalMock.html
@@ -1,0 +1,413 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <title>CNN.com - Transcripts</title>
+    <!--include virtual="/.element/ssi/misc/2.0/static_head.html"-->
+
+    <link rel="stylesheet" href="http://i.cdn.turner.com/cnn/.element/ssi/css/1.3/story.css" type="text/css">
+    <link rel="stylesheet" href="http://i.cdn.turner.com/cnn/.element/css/3.0/common_ref.css">
+    <link rel="stylesheet" href="http://i.cdn.turner.com/cnn/.element/css/2.0/common.css">
+    <script src="http://z.cdn.turner.com/cnn/.element/ssi/www/misc/4.0/static/js/jquery.min.js"></script>
+    <script language="JavaScript1.1" src="http://i.cdn.turner.com/cnn/.element/ssi/js/1.3/main.js" type="text/javascript"></script>
+
+    <script language="javascript" type="text/javascript">
+    <!--
+    var cnnSectionName = "Transcripts";
+    var cnnSectionFront = "Transcripts";
+    //-->
+    </script>
+    <script type="text/javascript">
+    var CNN = CNN || {};
+    var cnnDocDomain = '';
+    if (location.hostname.indexOf('cnn.com') > 0) {
+        cnnDocDomain = 'cnn.com';
+    }
+    if (location.hostname.indexOf('turner.com') > 0) {
+        if (document.layers) {
+            cnnDocDomain = 'turner.com:' + location.port;
+        } else {
+            cnnDocDomain = 'turner.com';
+        }
+    }
+    if (cnnDocDomain) {
+        document.domain = cnnDocDomain;
+    }
+    // DO NOT PUT ANYTHING BENEATH THIS!
+    </script>
+    <!-- <script>
+    #include virtual="/.element/ssi/auto/1.3/js/daily.txt"-
+    </script> -->
+
+    <style type="text/css">
+    a .cnnBannerLinked {
+      color: #c00;
+    }
+    #cnnReskin {
+        width: 770px;
+        margin: 0 auto;
+    }
+    #cnnReskin #cnnPageTitle {
+        font: bold 32px Arial;
+        color: #ca0002;
+        border-bottom: 3px solid #003366;
+        margin-bottom: 12px;
+    }
+    #cnnReskin .cnnBoxContent {
+        padding: 6px 16px;
+    }
+    .nav .buckets a {
+        text-decoration: none;
+    }
+    <!-- .cnn6pxPad {
+        padding: 6px;
+    }
+    .cnnTransHeaders,
+    .cnnTransDate {
+        font-family: verdana, arial, sans-serif;
+    }
+    .cnnTransCal,
+    .cnnTransHead,
+    .cnnTransStoryHead,
+    .cnnTransSubHead {
+        font-family: arial, helvetica, sans-serif;
+    }
+    .cnnTransHeaders,
+    .cnnTransDate,
+    .cnnTransProv {
+        font-size: 10px;
+    }
+    .cnnTransSubHead {
+        font-size: 12px;
+    }
+    .cnnTransHead {
+        font-size: 14px;
+    }
+    .cnnTransStoryHead {
+        font-size: 16px;
+    }
+    .cnnTransHeaders,
+    .cnnTransDate,
+    .cnnTransHead,
+    .cnnTransStoryHead,
+    .cnnTransSubHead,
+    .cnnTransProv {
+        font-weight: bold;
+    }
+    .cnnTransHeaders,
+    .cnnTransSubHead,
+    .cnnTransDate {
+        color: #000000;
+    }
+    .cnnTransHead,
+    .cnnTransStoryHead {
+        color: #CC0000;
+    }
+    .cnnTransHeaders,
+    .cnnTransCal {
+        padding: 6px;
+    }
+    .cnnTransProv {
+        font-family: verdana, helvetica, sans-serif;
+        padding: 1px;
+    }
+    //-->
+    </style>
+
+
+<body id="contentArea" onload="cnnHandleCSIs()">
+    <!--include virtual="/editionssi/misc/2.0/header/sect/ref/min/generic.html"-->
+    <script>var CNNENV = "http://www.cnn.com"; window.CNNSTATICSECTION = '';</script>
+<div class="cnn-js-chrome-wrapper">
+    <div class="cnn-js-navigation" data-type="nav"></div>
+</div>
+<script src="https://z.cdn.turner.com/cnn/.element/ssi/www/misc/4.0/static/js/static-chrome-companion.min.js"></script>
+
+
+    <div id="cnnContainer">
+        <div id="cnnContentContainer">
+            <!-- breaking news banner -->
+            <!--include virtual="/editionssi/breaking_news/2.0/banner.html"-->
+            <div id="cnnMainContent">
+                <div id="cnnReskin">
+                    <div class="cnnWCBox">
+                        <div class="cnnBoxHeader">
+                            <div></div>
+                        </div>
+                        <div class="cnnBoxContent" align="center">
+                            <div id="cnnPageTitle" align="left">
+                                <!-- Header -->
+                                <table cellpadding="0" cellspacing="0" border="0">
+                                    <tr valign="bottom">
+                                        <td width="264">
+                                            <a href="/TRANSCRIPTS"><img src="http://i.cdn.turner.com/cnn/.element/img/1.0/sect/TRANSCRIPTS/header.transcripts.gif" alt="TRANSCRIPTS" width="259" height="32" hspace="0" vspace="0" border="0" align="left" />
+                                            </a>
+                                        </td>
+                                        <td width="370" align="left"><span style="font-family: verdana, helvetica, sans-serif; font-size:10px; font-weight:bold; padding:1px;"><a HREF="javascript:CNN_openPopup('/TRANSCRIPTS/providers/frameset.exclude.html','620x430','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=no,width=620,height=430')">Transcript Providers</a></span>
+                                        </td>
+                                    </tr>
+                                </table>
+                                <!-- /Header -->
+                            </div>
+                            <div class="clear"><img src="http://i.a.cnn.net/cnn/images/1.gif" width="1" height="5" border="0" alt="" />
+                            </div>
+                            <!-- Content -->
+
+
+                            <table cellpadding="0" cellspacing="0" border="0" width="634">
+
+                                <tr valign="top">
+                                    <td>
+                                        <!-- ============ -->
+                                        <!-- CONTENT AREA -->
+                                        <!-- ============ -->
+                                        <table width="634" height="250" cellpadding="0" cellspacing="0" border="0">
+                                            <tr valign="top">
+                                                <td class="cnnBodyText" bgcolor="#ffffff" width="288">
+                                                    <table width="288" cellpadding="0" cellspacing="0" border="0" bgcolor="#666666"><tr valign="bottom">
+<td width="6"><img src="http://i.cnn.net/cnn/images/1.gif" width="6" height="24" hspace="0" vspace="0" alt="" border="0"></td>
+<td width="96"><img src="http://i.cnn.net/cnn/.element/img/1.0/sect/TRANSCRIPTS/shows_by_day_header.gif" width="96" height="19" hspace="0" vspace="0" alt="" border="0"></td>
+<td><img src="http://i.cnn.net/cnn/images/1.gif" width="5" height="1" hspace="0" vspace="0" alt="" border="0"></td></tr>
+</table>
+<table width="288" cellpadding="0" cellspacing="0" border="0" bgcolor="#E7E7E7">
+  <tr>
+    <td bgcolor="#ffffff" colspan="13"><img src="http://i.cnn.net/cnn/images/1.gif" width="288" height="1" hspace="0" vspace="0" alt="" border="0"></td></tr>
+    <td width="52"><div class="cnnTransHeaders">Sun.</div></td>
+    <td bgcolor="#ffffff" width="1"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+    <td width="52"><div class="cnnTransHeaders">Mon.</div></td>
+    <td bgcolor="#ffffff" width="1"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+    <td width="52"><div class="cnnTransHeaders">Tues.</div></td>
+    <td bgcolor="#ffffff" width="1"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+    <td width="52"><div class="cnnTransHeaders">Wed.</div></td>
+    <td bgcolor="#ffffff" width="1"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+    <td width="52"><div class="cnnTransHeaders">Thurs.</div></td>
+    <td bgcolor="#ffffff" width="1"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+    <td width="52"><div class="cnnTransHeaders">Fri.</div></td>
+    <td bgcolor="#ffffff" width="1"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+    <td width="52"><div class="cnnTransHeaders">Sat.</div></td>
+  </tr>
+<tr><td bgcolor="#ffffff" colspan="13"><img src="http://i.cnn.net/cnn/images/1.gif" width="288" height="1" hspace="0" vspace="0" alt="" border="0"></td></tr>
+<tr><td bgcolor="#8DB3CE" colspan="13"><img src="http://i.cnn.net/cnn/images/1.gif" width="288" height="5" hspace="0" vspace="0" alt="" border="0"></td></tr>
+<tr><td bgcolor="#ffffff" colspan="13"><img src="http://i.cnn.net/cnn/images/1.gif" width="288" height="1" hspace="0" vspace="0" alt="" border="0"></td></tr>
+<tr><td><div class="cnnTransCal">&nbsp;</div></td><td bgcolor="#ffffff"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+<td><div class="cnnTransCal">&nbsp;</div></td><td bgcolor="#ffffff"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+<td><div class="cnnTransCal"><a href="/TRANSCRIPTS/2020.01.21.html">Jan.<BR> 21</a></div></td><td bgcolor="#ffffff"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+<td><div class="cnnTransCal"><a href="/TRANSCRIPTS/2020.01.22.html">Jan.<BR> 22</a></div></td><td bgcolor="#ffffff"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+<td><div class="cnnTransCal"><a href="/TRANSCRIPTS/2020.01.23.html">Jan.<BR> 23</a></div></td><td bgcolor="#ffffff"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+<td><div class="cnnTransCal"><a href="/TRANSCRIPTS/2020.01.24.html">Jan.<BR> 24</a></div></td><td bgcolor="#ffffff"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+<td><div class="cnnTransCal"><a href="/TRANSCRIPTS/2020.01.25.html">Jan.<BR> 25</a></div></td>
+</tr><tr><td bgcolor="#ffffff" colspan="13"><img src="http://i.cnn.net/cnn/images/1.gif" width="288" height="1" hspace="0" vspace="0" alt="" border="0"></td></tr><tr><td><div class="cnnTransCal"><a href="/TRANSCRIPTS/2020.01.26.html">Jan.<BR> 26</a></div></td><td bgcolor="#ffffff"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+<td><div class="cnnTransCal"><a href="/TRANSCRIPTS/2020.01.27.html">Jan.<BR> 27</a></div></td><td bgcolor="#ffffff"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+<td><div class="cnnTransCal"><a href="/TRANSCRIPTS/2020.01.28.html">Jan.<BR> 28</a></div></td><td bgcolor="#ffffff"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+<td><div class="cnnTransCal"><a href="/TRANSCRIPTS/2020.01.29.html">Jan.<BR> 29</a></div></td><td bgcolor="#ffffff"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+<td><div class="cnnTransCal"><a href="/TRANSCRIPTS/2020.01.30.html">Jan.<BR> 30</a></div></td><td bgcolor="#ffffff"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+<td><div class="cnnTransCal">&nbsp;</div></td><td bgcolor="#ffffff"><img src="http://i.cnn.net/cnn/images/1.gif" width="1" hspace="0" vspace="0" alt="" border="0"></td>
+<td><div class="cnnTransCal">&nbsp;</div></td>
+</tr><tr><td bgcolor="#ffffff" colspan="13"><img src="http://i.cnn.net/cnn/images/1.gif" width="288" height="10" hspace="0" vspace="0" alt="" border="0"></td></tr></TABLE>
+
+
+                                                    <!--include virtual="/.element/ssi/sect/TRANSCRIPTS/breaking.news.transcripts.html"-->
+
+
+                                                    <table width="288" cellpadding="0" cellspacing="0" border="0" bgcolor="#CC0000">
+                                                        <tr valign="bottom">
+                                                            <td width="6"><img src="http://i.cdn.turner.com/cnn/images/1.gif" width="6" height="24" hspace="0" vspace="0" alt="" border="0">
+                                                            </td>
+                                                            <td width="166"><img src="/.element/img/1.0/sect/TRANSCRIPTS/breaking_news_header.gif" width="166" height="19" hspace="0" vspace="0" alt="" border="0">
+                                                            </td>
+
+                                                        </tr>
+                                                        <tr>
+                                                            <td colspan="2" bgcolor="#E7E7E7" class="cnnSectBulletItems">
+                                                                <div class="cnn6pxPad">
+                                                                    &#149;&nbsp;<a href="/TRANSCRIPTS/bn.html">Click here for Breaking News Transcripts</a>
+                                                                    <BR>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+
+                                                    </table>
+
+
+                                                </td>
+                                                <td rowspan="2"><img src="http://i.cdn.turner.com/cnn/images/1.gif" width="10" height="250" hspace="0" vspace="0" alt="" border="0">
+                                                </td>
+                                                <td rowspan="2">
+                                                    <!-- ADSPACE: transcripts/rgt.336x280 -->
+
+<!-- CALLOUT|http://ads.cnn.com/html.ng/site=cnn&cnn_position=336x280_rgt&cnn_rollup=transcript&page.allowcompete=yes&params.styles=fs|CALLOUT -->
+<div id="ad-803645" align="center" style="padding: 0; margin: 0; border: 0;"></div>
+<script type="text/javascript">
+cnnad_createAd("803645","http://ads.cnn.com/html.ng/site=cnn&cnn_position=336x280_rgt&cnn_rollup=transcript&page.allowcompete=yes&params.styles=fs","280","336");
+cnnad_registerSpace(803645,336,280);
+</script>
+
+
+
+
+
+
+                                                </td>
+                                            </tr>
+                                            <tr valign="bottom">
+                                                <td>
+                                                    <!-- ON CNN box -->
+                                                    <table width="288" cellpadding="3" cellspacing="0" border="0" bgcolor="#E7E7E7">
+                                                        <tr>
+                                                            <td>
+                                                                <table width="282" cellpadding="0" cellspacing="0" border="0" bgcolor="#ffffff">
+                                                                    <tr>
+                                                                        <td bgcolor="#ffffff" class="cnnBodyText"><img src="/.element/img/1.0/sect/TRANSCRIPTS/icon.gif" width="44" height="34" hspace="0" vspace="0" alt="" border="0" align="left">
+                                                                            <div style="padding-top:3px;padding-right:3px;padding-bottom:3px;padding-left:3px;"><a href="https://www.cnn.com/tv/schedule/cnn/">Check the program schedule ON CNN TV</a> to find the name of show you saw at a specific time.
+                                                                                <BR>
+                                                                            </div>
+                                                                        </td>
+                                                                    </tr>
+                                                                </table>
+                                                            </td>
+                                                        </tr>
+                                                    </table>
+                                                    <!-- ON CNN box -->
+                                                </td>
+                                            </tr>
+                                        </table>
+                                        <table width="634" cellpadding="0" cellspacing="0" border="0">
+                                            <tr>
+                                                <td colspan="3"><img src="http://i.cdn.turner.com/cnn/images/1.gif" width="634" height="10" hspace="0" vspace="0" alt="" border="0">
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td colspan="3">
+                                                    <table width="634" cellpadding="0" cellspacing="0" border="0" bgcolor="#666666">
+  <tr valign="bottom">
+    <td width="6"><img src="http://i.cnn.net/cnn/images/1.gif" width="6" height="24" hspace="0" vspace="0" alt="" border="0"></td>
+    <td width="125"><img src="/.element/img/1.0/sect/TRANSCRIPTS/shows_by_cat_header.gif" width="125" height="19" hspace="0" vspace="0" alt="" border="0"></td>
+    <td width="503"><img src="http://i.cnn.net/cnn/images/1.gif" width="503" height="1" hspace="0" vspace="0" alt="" border="0"></td>
+  </tr>
+</table>
+<style>
+    #cnn_categorytable{text-align:left;}
+</style>
+<table width="634" cellpadding="6" cellspacing="0" border="0" bgcolor="#E7E7E7" id="cnn_categorytable">
+    <tr valign="top">
+        <td width="34%">
+            <div class="cnnTransDate">NEWS</div>
+            <span class="cnnSectBulletItems">
+                &#149;&nbsp;<a href="/TRANSCRIPTS/acd.html">Anderson Cooper 360&deg;</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/ath.html">At This Hour</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/cnr.html">CNN Newsroom</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/crn.html">CNN Right Now</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/siu.html">CNN: Special Investigations Unit</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/csr.html">CNN Special Reports</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/cnnt.html">CNN Tonight</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/CPT.html">Cuomo Prime Time</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/es.html">Early Start</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/ebo.html">Erin Burnett OutFront</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/cg.html">The Lead with Jake Tapper</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/sitroom.html">The Situation Room</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/se.html">Special Events</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/sn.html">CNN 10</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/nday.html">New Day</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/ndaysat.html">New Day Saturday</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/ndaysun.html">New Day Sunday</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/wolf.html">Wolf</a><br/>
+            </span>
+        </td>
+        <td width="33%">
+            <div class="cnnTransDate">INTERVIEW AND DEBATE</div>
+            <span class="cnnSectBulletItems">
+                &#149;&nbsp;<a href="/TRANSCRIPTS/ip.html">Inside Politics</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/rs.html">Reliable Sources</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/smer.html">Smerconish</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/sotu.html">State of the Union</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/af.html">The Axe Files</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/vjs.html">The Van Jones Show</a><br/>
+                <br/>
+            </span>
+            <div class="cnnTransDate">NEWS FOR LIVING</div>
+            <span class="cnnSectBulletItems">
+                &#149;&nbsp;<a href="/TRANSCRIPTS/vssg.html">Vital Signs with Dr. Sanjay Gupta</a><br/>
+            </span>
+        </td>
+        <td width="33%">
+            <div class="cnnTransDate">INTERNATIONAL NEWS</div>
+            <span class="cnnSectBulletItems">
+                &#149;&nbsp;<a href="/TRANSCRIPTS/ampr.html">Amanpour</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/ctw.html">Connect the World</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/fzgps.html">Fareed Zakaria GPS</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/id.html">International Desk</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/nwsm.html">News Stream</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/qmb.html">Quest Means Business</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/se.html">Special Events</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/wrn.html">Hala Gorani Tonight</a><br/>
+                &#149;&nbsp;<a href="/TRANSCRIPTS/bbn.html">The Brief with Bianca Nobilo</a><br/>
+                <br/>
+            </span>
+            <div class="cnnTransDate">HLN</div>
+            <span class="cnnSectBulletItems">
+                &#149;&nbsp;<a href="/TRANSCRIPTS/ptab.html">Crime and Justice with Ashleigh Banfield</a><br/>
+            </span>
+        </td>
+    </tr>
+</table>
+
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td colspan="3"><img src="http://i.cdn.turner.com/cnn/images/1.gif" width="634" height="10" hspace="0" vspace="0" alt="" border="0">
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td colspan="3">
+                                                    <div id="contextualLinks"></div>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                        <!-- ============= -->
+                                        <!-- /CONTENT AREA -->
+                                        <!-- ============= -->
+                                    </td>
+                                </tr>
+                            </table>
+                            <!-- /Content -->
+                        </div>
+                        <!-- /cnnBoxContent -->
+                        <div class="cnnBoxFooter">
+                            <div></div>
+                        </div>
+                    </div>
+                    <!-- /cnnWCBox -->
+                    <div class="clear"><img src="http://i.a.cnn.net/cnn/images/1.gif" width="1" height="1" border="0" alt="" />
+                    </div>
+                </div>
+                <!-- /cnnReskin -->
+            </div>
+            <!-- /cnnMainContent -->
+        </div>
+        <!-- /cnnContentContainer -->
+    </div>
+    <!-- /cnnContainer -->
+    <div style="background:#fff" align="center">
+        <!-- include virtual="/editionssi/misc/2.0.legacy/footer/ref/min/footer.html"-->
+  <div class="cnn-js-chrome-wrapper">
+    <div class="cnn-js-navigation" data-type="footer"></div>
+</div>
+<script type="text/javascript" src="//agility.cnn.com/turner/cnn-prod/Bootstrap.js"></script>
+
+<script>
+var cnn_metadata = cnn_metadata || {};
+cnn_metadata.template_type_content = cnn_metadata.template_type_content || '';
+CNN.omniture = CNN.omniture || {};
+CNN.omniture.template_type = CNN.omniture.template_type || '';
+</script>
+
+    </div>
+    <div id="csiIframe" style="visibility:hidden;height:0px;width:0px;"></div>
+    <img src="//cdn.cnn.com/cnn/images/1.gif" alt="" id="TargetImage" name="TargetImage" width="1" height="1"
+onLoad="getAdHeadCookie(this)"><img src="//cdn.cnn.com/cnn/images/1.gif" alt="" id="TargetImageDE"
+name="TargetImageDE" width="1" height="1" onLoad="getDEAdHeadCookie(this)">
+
+</body>
+
+</html>

--- a/src/server/workers/crawlers/CnnCrawlers/__test__/data/transcriptListMock.html
+++ b/src/server/workers/crawlers/CnnCrawlers/__test__/data/transcriptListMock.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta http-equiv="content-type" content="text/html; charset=iso-8859-1"/>
+<title>CNN.com - Transcripts</title>
+
+<link rel="stylesheet" href="http://i.cnn.net/cnn/.element/ssi/css/1.3/story.css" type="text/css">
+<script language="JavaScript1.1" src="http://i.cnn.net/cnn/.element/ssi/js/1.3/main.js" type="text/javascript"></script>
+
+<script>
+  var cnnSiteWideCurrDate = new Date(2013, 1, 12);
+</script>
+
+<style type="text/css">
+<!--
+.cnnTransHeaders,
+.cnnTransDate
+{ font-family: verdana, arial, sans-serif; }
+
+.cnnTransCal,
+.cnnTransHead,
+.cnnTransStoryHead,
+.cnnTransSubHead
+{ font-family: arial, helvetica, sans-serif; }
+
+.cnnTransHeaders,
+.cnnTransDate,
+.cnnTransProv
+{ font-size: 10px; }
+
+.cnnTransSubHead
+{ font-size: 12px; }
+
+.cnnTransHead
+{ font-size: 14px; }
+
+.cnnTransStoryHead
+{ font-size: 16px; }
+
+.cnnTransHeaders,
+.cnnTransDate,
+.cnnTransHead,
+.cnnTransStoryHead,
+.cnnTransSubHead,
+.cnnTransProv
+{ font-weight: bold; }
+
+.cnnTransHeaders,
+.cnnTransSubHead,
+.cnnTransDate
+{ color: #000000; }
+
+.cnnTransHead,
+.cnnTransStoryHead
+{ color: #CC0000; }
+
+.cnnTransHeaders,
+.cnnTransCal
+{ padding: 6px; }
+
+.cnnTransProv
+{font-family: verdana, helvetica, sans-serif; padding:1px;}
+
+#cnnContainer {
+  font-size: 16px;
+  line-height: 1.75;
+  margin: 10px auto 0;
+  max-width: 1100px;
+}
+
+.breaking-news-showing #cnnContainer {
+  margin-top: 20px;
+}
+
+#cnnContainer a {
+  color: #006598;
+}
+
+#cnnContainer a:hover {
+  color: #C00;
+}
+
+//-->
+</style>
+</head>
+
+<body id="contentArea" onload="cnnHandleCSIs()">
+<script>window.CNNSTATICSECTION = '';</script>
+<div class="cnn-js-chrome-wrapper">
+    <div class="cnn-js-navigation" data-type="nav"></div>
+</div>
+<script>var CNNENV = "//www.cnn.com";</script>
+<script src="//z.cdn.turner.com/cnn/.element/ssi/www/misc/4.0/static/js/static-chrome-companion.min.js?v23"></script>
+
+
+
+<div id="cnnContainer">
+  <div id="cnnContentContainer">
+    <!-- breaking news banner -->
+    <!--include virtual="/editionssi/breaking_news/2.0/bannerCSI.html"-->
+    <div id="cnnMainContent">
+      <div id="cnnReskin">
+        <div class="cnnWCBox">
+          <div class="cnnBoxHeader"><div></div></div>
+          <div class="cnnBoxContent">
+            <div id="cnnPageTitle">
+              <!-- Header -->
+              <table cellpadding="0" cellspacing="0" border="0"><tr valign="bottom"><td width="264"><a href="/TRANSCRIPTS"><img src="http://i.cnn.net/cnn/.element/img/1.0/sect/TRANSCRIPTS/header.transcripts.gif" alt="TRANSCRIPTS" width="259" height="32" hspace="0" vspace="0" border="0" align="left"/></a></td><td width="370" align="left"><span style="font-family: verdana, helvetica, sans-serif; font-size:10px; font-weight:bold; padding:1px;"><a HREF="javascript:CNN_openPopup('/TRANSCRIPTS/providers/frameset.exclude.html','620x430','toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=no,resizable=no,width=620,height=430')">Transcript Providers</a></span></td></tr></table>
+              <!-- /Header -->
+            </div>
+            <div class="clear"><img src="http://i.a.cnn.net/cnn/images/1.gif" width="1" height="5" border="0" alt=""/></div>
+            <!-- Content -->
+
+            <!-- table width="770" cellpadding="0" cellspacing="0" border="0" id="cnnArticleWireFrame" -->
+            <table cellpadding="0" cellspacing="0" border="0" id="cnnArticleWireFrame">
+              <tr><td colspan="2" bgcolor="#ffffff"><img src="http://i.cnn.net/cnn/images/1.gif" width="634" height="1" hspace="0" vspace="0" alt="" border="0"/></td></tr>
+
+              <tr valign="top">
+                <td><a name="ContentArea"></a><div style="padding-left:10px;">
+                  <table width="346" height="280" cellpadding="0" cellspacing="0" border="0" align="right">
+                    <tr valign="top">
+                      <td><img src="http://i.cnn.net/cnn/images/1.gif" width="10" height="280" hspace="0" vspace="0" alt="" border="0"></td>
+                      <td width="336" align="right"><!-- ADSPACE: transcripts/rgt.336x280 -->
+
+<!-- CALLOUT|http://ads.cnn.com/html.ng/site=cnn&cnn_position=336x280_rgt&cnn_rollup=transcript&page.allowcompete=yes&params.styles=fs|CALLOUT -->
+<div id="ad-803645" align="center" style="padding: 0; margin: 0; border: 0;"></div>
+<script type="text/javascript">
+cnnad_createAd("803645","http://ads.cnn.com/html.ng/site=cnn&cnn_position=336x280_rgt&cnn_rollup=transcript&page.allowcompete=yes&params.styles=fs","280","336");
+cnnad_registerSpace(803645,336,280);
+</script>
+
+
+
+
+
+<br clear="all"/>
+                      </td>
+                    </tr>
+                  </table>
+
+
+  <table width="288" cellpadding="0" cellspacing="0" border="0" bgcolor="#666666">
+  <tr valign="bottom">
+    <td><img src="http://i.cnn.net/cnn/images/1.gif" width="6" height="24" hspace="0" vspace="0" alt="" border="0"></td>
+    <td><img src="http://i.cnn.net/cnn/.element/img/1.0/sect/TRANSCRIPTS/shows_by_cat_white_header.gif" width="125" height="19" hspace="0" vspace="0" alt="" border="0"></td>
+    <td align="left">&nbsp;</td>
+  </tr>
+  </table>
+
+  <P><a href="/TRANSCRIPTS/" class="cnnTransProv">Return to Transcripts main page</a></P>
+
+  <P class="cnnTransHead">CNN Transcripts for January 21, 2020</P>
+  <P class="cnnBodyText"><b>Note:</b> This page is continually updated as new transcripts become available. If you cannot find a specific segment, check back later.</P>
+  <div class="cnnTransDate">ANDERSON COOPER 360 DEGREES</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/acd.02.html">Sen. Richard Blumenthal (D-CT) Is Interviewed About How The Vote Is Going On And How He Sees The Impeachment Hearing Generally; Political Interest Seen On The Senate; Trial For The Articles Of Impeachment Of President Donald Trump. Aired 11p-12a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/acd.01.html">House Managers, Trump Legal Team Clash Over Trial Rules. Aired on 8-9p ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">AT THIS HOUR</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/ath.01.html">Did Not Air 11a-12p ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">CNN 10</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/sn.01.html">U.S. Senate Opens Its Impeachment Trial for President Trump; Mysterious Virus Surfaces in Asia; Studies Examine Screen time and Children`s Brains</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">CNN LIVE EVENT/SPECIAL</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/se.08.html">House Managers, Trump Legal Team Debate Trial Rules; Significant Change to McConnell's Proposed Rules. Aired 1:30-2p ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/se.02.html">Live Coverage of House Impeachment Managers' Press Conference; Pros and Cons of Mitch McConnell's Senate Rules; Recent Polling Shows Majority of Americans Favor Including New Evidence in Senate Trial. Aired 10:30-11a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/se.09.html">The Impeachment Trial of Donald J. Trump; Sen. McConnell Revises Trial Rules; House and Trump Legal Team Debate. Aired 2-2:30p ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/se.11.html">The Impeachment Trial of Donald J. Trump; Mitch McConnell Agrees to Impeachment Trial Rules Changes; Interview With Sen. Jeff Merkley (D-OR). Aired 3-3:30p ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/se.12.html">The Impeachment Trial of Donald Trump; House Managers and Trump Team Debate Trial Rules. Aired 3:30-4p ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/se.13.html">Impeachment Trial Kicks Off With Fierce Battle Over Rules. Aired 4-4:30p ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/se.03.html">Democratic Leaders Respond to Rules Change at Press Conference. Aired 11-11:30a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/se.14.html">The Impeachment Trial of Donald J. Trump. Aired 4:30-5p ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/se.01.html">Senators Expected To Clash Over Impeachment Trial Rules; CNN Reports, White House, Senate GOP Working To Limit Possible Bolton Testimony; Adam Schiff, House Manager Speakers Before The Senate Trial Begins; Interview With Sen. Mazie Hirono (D-HI). Aired 10-10:30a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/se.04.html">Schumer: McConnell Wants to Cover Up for Trump; Democrats Push for Witnesses & Documents During Senate Trial; Democrats Demand Pat Cipollone Hand Over Firsthand Information; Constitutional Law Professor, Laurence Tribe, Discusses Impeachment, Democrats' Demands for Witnesses & Documents; Former Congressman & House Manager in Clinton Impeachment, Chris Cannon, Discusses His Warning to Democrats. Aired 11:30a-12p ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/se.05.html">GOP's Mitch McConnell Looks To Impose Speedy Senate Trial; Senators Expected To Clash Over Impeachment Trial Rules; CNN: White House, Senate GOP Working To Keep John Bolton From Testifying Publicly; Soon: Impeachment Trial Kicks Off With Fierce Battle Over Rules; Senators, Trump Lawyers Begin Arriving For Impeachment Trial. Aired 12-12:30p ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/se.07.html">Senate Debates Impeachment Trial Rules. Aired 1-1:30p ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/se.10.html">Impeachment Trial Of President Trump In U.S. Senate; McConnell Revises Proposed Rule, House Record "Will Be" Entered Into Evidence Instead Of "May Be" Entered. Aired 2:30-3p ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/se.15.html">Schumer Proposes Amendment To Subpoena State Department Docs Related To Impeachment; GOP's Collins "Likely" To Support Witnesses In Senate Trial; House Managers, Trump Legal Team Debate Rules. Aired 5- 6p ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/se.16.html">The Impeachment Trial Of Donald J. Trump; Senate Voting On Tabling Amendment To Subpoena State Department Documents. Aired 6-7p ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/se.06.html">Impeachment Trial Kicks Off With Fierce Battle Over Rules; Trump's Impeachment Trial To Begin With Senate Clashes. Aired 12:30-1p ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">CNN NEWSROOM</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/cnr.03.html">Did Not Air 10-11a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/cnr.04.html">Did Not Air 2-3p ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/cnr.05.html">Did Not Air 3-4p ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/cnr.20.html">President Trump Attends World Economic Forum in Davos; Senate Republicans Wants Rush Impeachment; Asia on High Alert; Taal Residents Not Yet Out of the Woods. Aired 3-3:30a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/cnr.01.html">Trump's Impeachment Trial to Begin Today; House Managers Call White House Counsel Cipollone a "Fact Witness" and Demand He Discloses All "First-Hand Knowledge"; Senators Expected to Clash Over Impeachment Trial Rules in First Senate Impeachment Trial; Impeachment Trial Kicks Off with Fierce battle Over Rules. Aired 9-9:30a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/cnr.18.html">U.S. Senate To Begin President's Impeachment Trial; China: New Virus Can Be Transmitted Between Humans; Meng Wanzhou Extradition Hearing Begins In Canada; Davos 2020; Protest in Virginia Ends Peacefully Despite Concerns; U.S. Senate Goes Phone Free for Impeachment. Aired 1-2a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/cnr.19.html">Trump on Trial; Davos 2020; Coronavirus Outbreak; Huawei Hearing; U.S. Senate To Begin Trump Impeachment Trial; Activist Greta Thunberg Headlining Climate Debates; U.S. Senate Goes Phone-Free For Impeachment. Aired 2-3a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/cnr.02.html">Sen. Chris Van Hollen (D-MD) is Interviewed about Impeachment Trial; Clinton talks about Sanders; Clash over Impeachment Rules; Trump at Economic Summit; Roberts Faces Impeachment Test. Aired 9:30- 10a</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/cnr.17.html">Rules Established for Trump's Senate Impeachment Trial; Trump to Attend World Economic Forum During Trial; Prince Harry Expresses 'Great Sadness' Over Decision to Step Back; Scientist Says Volcano in Philippines is 'Recharging'; Coronavirus Outbreak. Aired 12-1a ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">CNN RIGHT NOW</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/crn.01.html">Did Not Air 1-2p ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">CNN TONIGHT</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/cnnt.02.html">Did Not Air 11p-12a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/cnnt.01.html">Senate Votes On Democrats' Amendments. Aired 10-11p ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">CNN'S AMANPOUR</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/ampr.01.html">Did Not Air 1-2p ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">CONNECT THE WORLD</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/ctw.01.html">Did Not Air 10-11a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/ctw.02.html">Did Not Air 11a-12p ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">CUOMO PRIME TIME</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/CPT.01.html">Senate Debates Amendment To Subpoena Mick Mulvaney; Senate Votes Against Hearing Mick Mulvaney Testimony; Debate Over Subpoena Of Department Of Defense Documents. Aired 9-10p ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">EARLY START</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/es.04.html">Democrats Furious Over Impeachment Trial Rules; President Trump Heads To Davos Amid Impeachment Trial; Countdown To Iowa Caucuses: 13 Days. Aired 5:30-6a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/es.01.html">Trump Impeachment Trial Begins; GOP Pushes for Fast Trial; Washington Post: Trump Team Trying to Keep Bolton from Spotlight. Aired 4-4:30a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/es.02.html">Trump Impeachment Trial: Long Days of Impeachment Trial Opening Arguments; Dems Furious Over Impeachment Trail Rules; Washington Post: Trump Allies Working to Prevent Bolton Testimony; 4 Dead from New Virus Strain in China. Aired 4:30-5a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/es.03.html">Trump Impeachment Trial: Senate Will Vote on Whether to Admit House Evidence; Dems Furious Over Impeachment Trial Rules; Washington Post: Trump Allies Working to Prevent Bolton Testimony; 4 Dead from New Virus Strain in China; Celtics Hand Lakers Worst Loss of Season. Aired 5-5:30a ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">ERIN BURNETT OUTFRONT</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/ebo.01.html">House Managers, Trump Legal Team Clash Over Trial Rules; Sen. Chris Murphy (D-CT) is Interviewed About the Senate Impeachment Trial. Aired 7-8p ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">FIRST MOVE WITH JULIA CHATTERLEY</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/fmjc.01.html">President Trump Tells The Davos Elite To Avoid The Doom And Gloom Prediction Of The Climate Apocalypse; Activist Greta Thunberg Says Planting Trees Is Certainly Good, But Nothing Has Actually Been Done To Tackle Climate Change Itself; U.S. Senators Are About To Start President Donald Trump's Impeachment Trial. Aired 9-10a ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">HALA GORANI TONIGHT</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/wrn.01.html">Did Not Air 2-3p ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">INSIDE POLITICS</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/ip.01.html">Did Not Air 12p-1p ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">NEW DAY</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/nday.01.html">Impeachment Trial to Begin with Fierce Debate Over Rules; Trump Lawyers, Senate Allies Push to Ensure Bolton Does Not Testify Publicly; Trump Speaks at World Economic Forum. Aired 6-6:30a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/nday.05.html">Senate Majority Leader Mitch McConnell Proposes Rules for Senate Impeachment Hearing; Hillary Clinton Criticizes Bernie Sanders in New Documentary; Rep. Zoe Lofgren (D-CA) is Interviewed About the Impeachment Trial and Being a House Impeachment Manager. Aired 8-8:30a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/nday.02.html">National Polls on Impeachment; Debate over Impeachment Rules; Sanders Apologizes to Biden. Aired 6:30-7a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/nday.03.html">Impeachment Trial Begins with Rules Debate; Looking Back at Impeachment History; Sanders Apologizes to Biden; Aired 7:00-7:30a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/nday.06.html">New Book on President Trump; New Trump Poll Numbers; Clinton Won't Commit. Aired 8:30-9a ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/nday.04.html">Sanders Apologizes To Biden For Supporter Alleging Corruption; Four Dem Senators Sidelined From Campaign During Impeachment; Fact- Checking Five Arguments From Trump's Legal Team; Sen. Chuck Schumer (D-NY) Discusses About His Reaction To The Proposed Rules By Senator McConnell About The Senate Impeachment Trial; Dem Leader Chuck Schumer On Battle Over Impeachment Rules; Battle Over Impeachment Witnesses Heats Up; Six Deaths, Nearly 300 Cases Of Wuhan Coronavirus. Aired 7:30-8a ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">QUEST MEANS BUSINESS</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/qmb.01.html">Did Not Air 3-4p ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">THE BRIEF WITH BIANCA NOBILO</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/bbn.01.html">Did Not Air 5-5:30p ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">THE LEAD WITH JAKE TAPPER</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/cg.01.html">Did Not Air 4-5p ET</a><BR>
+</div>
+
+<BR><BR>
+
+<div class="cnnTransDate">THE SITUATION ROOM</div>
+<div class="cnnSectBulletItems">&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/sitroom.01.html">Did Not Air 5-6p ET</a><BR>
+&#149;&nbsp;<a href="/TRANSCRIPTS/2001/21/sitroom.02.html">Did Not Air 6-7p ET</a><BR>
+</div>
+
+<BR><BR>
+
+              </div></td>
+            </tr>
+          </table>
+
+
+            <!-- /Content -->
+          </div><!-- /cnnBoxContent -->
+          <div class="cnnBoxFooter"><div></div></div>
+        </div><!-- /cnnWCBox -->
+        <div class="clear"><img src="http://i.a.cnn.net/cnn/images/1.gif" width="1" height="1" border="0" alt=""/></div>
+      </div><!-- /cnnReskin -->
+    </div><!-- /cnnMainContent -->
+  </div><!-- /cnnContentContainer -->
+<script>var CNN = CNN || {}; </script>
+<div class="cnn-js-chrome-wrapper">
+    <div class="cnn-js-navigation" data-type="footer"></div>
+</div>
+<script type="text/javascript" src="//agility.cnn.com/turner/cnn-prod/Bootstrap.js"></script>
+
+
+</div><!-- /cnnContainer -->
+<img src="//cdn.cnn.com/cnn/images/1.gif" alt="" id="TargetImage" name="TargetImage" width="1" height="1"
+onLoad="getAdHeadCookie(this)"><img src="//cdn.cnn.com/cnn/images/1.gif" alt="" id="TargetImageDE"
+name="TargetImageDE" width="1" height="1" onLoad="getDEAdHeadCookie(this)">
+
+</body>
+</html>
+


### PR DESCRIPTION
This add two new component tests, one for CnnTranscriptListCrawler and one for CnnTranscriptPortalCrawler.

The tests raise the concern that, at least in the case of the portal crawler, the currently-in-spec functionality is not ideal (see #278) but these tests currently match the implementation.

RElated to #309 