### PR TITLE
Add support for a test database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: node_js
 
+services:
+  - postgresql
+
 before_script:
   - echo "Host $STAGING_SERVER" >> ~/.ssh/config
   - echo "StrictHostKeyChecking no" >> ~/.ssh/config
+  - psql -c 'create database alerts_test;' -U postgres
 
 script:
   - npm run lint

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ This is a node project, to set up your development environment...
 
 ### Set up postgres
 
-This project uses [postgres](https://www.postgresql.org/) to store its data.  You will need to either set up a local copy, or find a hosted solution. Be sure to remember the username and password you set up for this project. 
+This project uses [postgres](https://www.postgresql.org/) to store its data.  You will need to either set up a local copy, or find a hosted solution. Be sure to remember the username and password you set up for this project.
+
+You will need to set up two separate databases: one for testing and one for the actual application.  Having a distinct test database is a code-enforced requirement.
 
 ### Set up redis
 
@@ -30,7 +32,7 @@ You will need to configure your environment variables.  In production this can b
 > vi .env
 ```
 
-The `DATABASE_URL_DEVELOPMENT` template should match the `username` and `databasename` that you set up when installing postgres. 
+The database credentials (e.g. `DATABASE_URL_DEVELOPMENT` and `DATABASE_URL_TEST`) should match the relevant instances of `username` and `databasename` that you set up when installing postgres.
 
 ### Run Migrations
 

--- a/config/sequelize-config.js
+++ b/config/sequelize-config.js
@@ -1,6 +1,31 @@
+const assert = require('assert')
 const dotenv = require('dotenv')
 
 dotenv.config()
+
+// I'm not sure if this should be in an external utility, but given how odd sequelize config
+// is I would like to have this check be directly next to the area where configuration
+// is defined, in case it ever changes.
+//
+// It is CRITICAL that the test database never match produciton / dev, since tests can be
+// destructive to data.
+//
+// I'm wrapping this check in a method name anyway just for the sake of readability.
+const assertSafeDatabaseConfiguration = function() {
+  const testDatabaseURL = new URL(process.env.DATABASE_URL_TEST)
+  const devDatabaseURL = new URL(process.env.DATABASE_URL_DEVELOPMENT)
+  const prodDatabaseURL = new URL(process.env.DATABASE_URL_PRODUCTION)
+  assert(
+    testDatabaseURL.pathname !== devDatabaseURL.pathname,
+    `Test DB (${testDatabaseURL.pathname}) cannot match Development DB (${devDatabaseURL.pathname})`,
+  )
+  assert(
+    testDatabaseURL.pathname !== prodDatabaseURL.pathname,
+    `Test DB (${testDatabaseURL.pathname}) cannot match Production DB (${devDatabaseURL.pathname})`,
+  )
+}
+
+assertSafeDatabaseConfiguration()
 
 module.exports = {
   development: {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "lint": "./node_modules/.bin/eslint 'src/**/*.js'",
     "pretest": "NODE_ENV=test yarn migrate",
     "test": "jest",
-    "test:watch": "jest --verbose --watch",
     "migrate": "sequelize db:migrate",
     "queue:jobs:list": "babel-node -- src/scripts/listScheduledJobs",
     "queue:jobs:schedule": "babel-node -- src/scripts/scheduleJobs",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start": "concurrently 'yarn start-node' 'yarn parcel:dev'",
     "build": "babel src -d lib",
     "lint": "./node_modules/.bin/eslint 'src/**/*.js'",
+    "pretest": "NODE_ENV=test yarn migrate",
     "test": "jest",
     "test:watch": "jest --verbose --watch",
     "migrate": "sequelize db:migrate",
@@ -69,6 +70,7 @@
     "winston": "^3.2.1"
   },
   "jest": {
-    "cacheDirectory": "./.jestcache"
+    "cacheDirectory": "./.jestcache",
+    "setupFilesAfterEnv": ["./src/test/suiteSetup.js"]
   }
 }

--- a/src/test/suiteSetup.js
+++ b/src/test/suiteSetup.js
@@ -1,0 +1,11 @@
+import models from '../server/models'
+
+// We need to ensure DB connections are closed after each test suite is run.
+// This is because Sequelize does not automatically close its connection pools
+//
+// Note: since Jest runs tests in parallel it is not enough to close in a global
+// teardown.
+//
+// You can learn more about the problem here:
+// https://stackoverflow.com/questions/60217417/jest-tests-hang-due-to-open-sequelize-connections/60267873
+afterAll(() => models.sequelize.close())


### PR DESCRIPTION
This adds in the pipework to allow our tests to interact with a database.

It migrates the test database when tests are run, adds Travis support for postgres, adds some protection to make sure tests are never run on a production / dev database, and also fixes an issue with database connections that became a blocker after enabling the test DB on CI.

This does not look like a week of work but there was a big struggle / rabbit hole as outlined in [this SO issue](https://stackoverflow.com/questions/60217417/jest-tests-hang-due-to-open-sequelize-connections)

## To test this PR

Just run tests. (`yarn test`)

## Extra Setup

You will probably find that you need to update your environment variables so that your test DB is different from your prod / dev DB.  Since we weren't using test DB in the past it's likely that they were all pointing to the same place.

Resolves Issue #317