### PR TITLE
Remove ssh_known_hosts TravisCI addon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
 
-addons:
-  ssh_known_hosts:
-  - "$STAGING_SERVER"
-
 before_script:
   - echo "Host $STAGING_SERVER" >> ~/.ssh/config
   - echo "StrictHostKeyChecking no" >> ~/.ssh/config


### PR DESCRIPTION
TravisCI does not allow the use of environment variables when setting known hosts.  This has two effects for us:

1. It means that the ssh_known_hosts apparently never did anything
2. It means TravisCI has some error output when trying to set up known
   hosts using environment vars.

This removes the offending attempt.  I don't expect there to be any consequence for our CD processes.

Resolves #322