### PR TITLE
Store scrape log data more efficiently

### DIFF
--- a/src/server/migrations/20200225232115-refactor-scrape-logs-response-status.js
+++ b/src/server/migrations/20200225232115-refactor-scrape-logs-response-status.js
@@ -1,0 +1,97 @@
+import { runPromiseSequence } from '../utils'
+
+import { SCRAPE_RESPONSE_CODES } from '../workers/scrapers/constants'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.sequelize
+    .transaction(t => runPromiseSequence([
+      () => queryInterface.addColumn(
+        'scrape_logs',
+        'scrape_response_code',
+        {
+          type: Sequelize.STRING,
+        },
+        { transaction: t },
+      ),
+      () => queryInterface.addColumn(
+        'scrape_logs',
+        'scrape_response_message',
+        {
+          type: Sequelize.TEXT,
+        },
+        { transaction: t },
+      ),
+      () => queryInterface.sequelize.query(
+        `
+        UPDATE scrape_logs
+        SET    scrape_response_code = '${SCRAPE_RESPONSE_CODES.HTTP_SUCCESS}'
+        WHERE  result IS NOT NULL`,
+        { transaction: t },
+      ),
+      () => queryInterface.sequelize.query(
+        `
+        UPDATE scrape_logs
+        SET    scrape_response_code = COALESCE(
+                 SUBSTRING(error from '^[0-9]{3}'),
+                 '${SCRAPE_RESPONSE_CODES.NON_HTTP_ERROR}'
+                ),
+               scrape_response_message = error
+        WHERE  error IS NOT NULL`,
+        { transaction: t },
+      ),
+      () => queryInterface.removeColumn(
+        'scrape_logs',
+        'result',
+        { transaction: t },
+      ),
+      () => queryInterface.removeColumn(
+        'scrape_logs',
+        'error',
+        { transaction: t },
+      ),
+    ])),
+  down: (queryInterface, Sequelize) => queryInterface.sequelize
+    .transaction(t => runPromiseSequence([
+      () => queryInterface.addColumn(
+        'scrape_logs',
+        'result',
+        {
+          type: Sequelize.TEXT,
+        },
+        { transaction: t },
+      ),
+      () => queryInterface.addColumn(
+        'scrape_logs',
+        'error',
+        {
+          type: Sequelize.TEXT,
+        },
+        { transaction: t },
+      ),
+      () => queryInterface.sequelize.query(
+        `
+        UPDATE scrape_logs
+        SET    result = '${SCRAPE_RESPONSE_CODES.HTTP_SUCCESS}'
+        WHERE  scrape_response_code = '${SCRAPE_RESPONSE_CODES.HTTP_SUCCESS}'`,
+        { transaction: t },
+      ),
+      () => queryInterface.sequelize.query(
+        `
+        UPDATE scrape_logs
+        SET    error = scrape_response_message
+        WHERE  scrape_response_code != '${SCRAPE_RESPONSE_CODES.HTTP_SUCCESS}' OR
+               scrape_response_code IS NULL`,
+        { transaction: t },
+      ),
+      () => queryInterface.removeColumn(
+        'scrape_logs',
+        'scrape_response_code',
+        { transaction: t },
+      ),
+      () => queryInterface.removeColumn(
+        'scrape_logs',
+        'scrape_response_message',
+        { transaction: t },
+      ),
+    ])),
+}

--- a/src/server/models/ScrapeLog.js
+++ b/src/server/models/ScrapeLog.js
@@ -2,8 +2,8 @@ module.exports = (sequelize, DataTypes) => {
   const ScrapeLog = sequelize.define('ScrapeLog', {
     scrapeUrl: DataTypes.STRING(1024),
     scraperName: DataTypes.STRING,
-    result: DataTypes.TEXT,
-    error: DataTypes.TEXT,
+    scrapeResponseCode: DataTypes.STRING,
+    scrapeResponseMessage: DataTypes.TEXT,
   }, {})
   return ScrapeLog
 }

--- a/src/server/workers/scrapers/constants.js
+++ b/src/server/workers/scrapers/constants.js
@@ -22,3 +22,8 @@ export const STATEMENT_SCRAPER_PLATFORMS = {
   CNN_TRANSCRIPT: 'CNN',
   TWITTER_ACCOUNT: 'TWITTER',
 }
+
+export const SCRAPE_RESPONSE_CODES = {
+  NON_HTTP_ERROR: 'non-http-error',
+  HTTP_SUCCESS: '200',
+}


### PR DESCRIPTION
## Description

Previously, we stored each scrape's complete `result` or `error` response data in the `scrape_log` table for every scrape logged. This was fine during development, but is much weightier than necessary for permanence. For instance, we've accumulated 4.6GB of `result` data in production in fewer than five months. (We've stored 5MB of `error` data in the same time.)

This change replaces the `scrape_log.result` and `scrape_log.error` text columns with two new columns:

- `scrape_log.scrape_response_code` for storing the HTTP response code, or a `non-http-error` fallback
- `scrape_log.scrape_response_message` for storing an optional longer message, currently only used for storing error messages

It also adapts the `ScrapeLog` model to use these columns and includes a complex migration that coalesces legacy data into the new fields (and back, upon migration reversal).

However! This change intentionally removes the accumulated `scrape_log.result` data, so reversing the migration will _not_ restore previous successful result data.

**🚨Let me reiterate this very important point:🚨** This change is **destructive** and running the migration will **delete the `scrape_logs.result` data**. Undoing the migration will restore error data (since we keep those messages), but the `result` column for successful scrapes will simply contain the string `"200"`. (Yes, the migration survives being run and reversed repeatedly, with the caveat that original `result` contents will be gone [forever](https://getyarn.io/yarn-clip/172b7a36-0c61-49c5-beea-e3cab6065066).)

## Steps to Test

1. Look at your database and find both successful and unsuccessful `scrape_logs` rows (presence of `result` or `error` content).
2. Run `yarn migrate`.
3. Check those same rows; they should now have a `scrape_response_code` column set to `"200"` if they were successful or their appropriate HTTP error code (or `"non-http-error"`) if not, and errors should be stored in `scrape_response_message`.
4. Fire up the scraper and let it scrape some Twitter or CNN content.
5. Make sure new `scrape_logs` rows were created with expected response values.
6. To be real fancy, reverse the migration (`sequelize db:migrate:undo`) and make sure `result`/`error` columns are restored (sans original `result` data); just run `yarn migrate` again when you're done being impressed with me.

## Deploy Notes

- After deploying we will need to migrate with `yarn migrate`

## Related Issues

Resolves #137