### PR TITLE
Don’t check scrape time if beyond scrape horizon

### DIFF
--- a/src/server/queues/cnnTranscriptListCrawlerQueue/cnnTranscriptListCrawlerJobProcessor.js
+++ b/src/server/queues/cnnTranscriptListCrawlerQueue/cnnTranscriptListCrawlerJobProcessor.js
@@ -12,14 +12,16 @@ const scrapeTranscriptUrl = url => statementScraperQueue.add({ url })
 
 const processTranscriptUrl = async (url) => {
   const scraper = new CnnTranscriptStatementScraper(url)
-  const recentScrapeTime = await scraper.getMostRecentScrapeTime()
   const urlPublicationDate = extractPublicationDateFromTranscriptUrl(url)
-  if (recentScrapeTime) {
-    logger.debug(`Skipping: ${url} was scraped on ${recentScrapeTime.format('YYYY-MM-DD')}`)
-  } else if (isDateBeyondScrapeHorizon(urlPublicationDate)) {
+  if (isDateBeyondScrapeHorizon(urlPublicationDate)) {
     logger.debug(`Skipping: ${url} was published on ${urlPublicationDate} before the horizon`)
   } else {
-    scrapeTranscriptUrl(url)
+    const recentScrapeTime = await scraper.getMostRecentScrapeTime()
+    if (recentScrapeTime) {
+      logger.debug(`Skipping: ${url} was scraped on ${recentScrapeTime.format('YYYY-MM-DD')}`)
+    } else {
+      scrapeTranscriptUrl(url)
+    }
   }
 }
 


### PR DESCRIPTION
## Description
Previously, before scraping a CNN transcript URL, we performed a preflight check in this order:

1. Check the database: Have we ever scraped this URL before?
2. Extract the transcript date from the URL: Is it beyond our configured date horizon?

With that order, we _always_ hit the database, even when we’re going to reject the scrape in the very next check.

Since the order is not technically meaningful, we can reverse it to save ourselves many unnecessary database lookups.

This commit does just that.

## Steps to Test
Run the CNN portal crawler with `yarn queue:jobs:run:cnn-portal-crawler` and make sure nothing blows up. (If you wanted to, you could fiddle with your date horizon and do some performance profiling, but that seems extreme.)

## Deploy Notes
None. Fire and forget.

## Related Issues
Resolves #277
