### PR TITLE
Retry unsuccessful CNN scrapes

### DIFF
--- a/src/server/queues/cnnTranscriptListCrawlerQueue/cnnTranscriptListCrawlerJobProcessor.js
+++ b/src/server/queues/cnnTranscriptListCrawlerQueue/cnnTranscriptListCrawlerJobProcessor.js
@@ -16,9 +16,9 @@ const processTranscriptUrl = async (url) => {
   if (isDateBeyondScrapeHorizon(urlPublicationDate)) {
     logger.debug(`Skipping: ${url} was published on ${urlPublicationDate} before the horizon`)
   } else {
-    const recentScrapeTime = await scraper.getMostRecentScrapeTime()
-    if (recentScrapeTime) {
-      logger.debug(`Skipping: ${url} was scraped on ${recentScrapeTime.format('YYYY-MM-DD')}`)
+    const recentSuccessfulScrapeTime = await scraper.getMostRecentSuccessfulScrapeTime()
+    if (recentSuccessfulScrapeTime) {
+      logger.debug(`Skipping: ${url} was successfully scraped on ${recentSuccessfulScrapeTime.format('YYYY-MM-DD')}`)
     } else {
       scrapeTranscriptUrl(url)
     }


### PR DESCRIPTION
## Description

Before this change, we wouldn’t re-scrape a CNN URL that we’d already seen before, even if the scrape was unsuccessful. This protects us from repeatedly scraping broken links in perpetuity, but also means if a URL was temporarily broken, we don’t retry it later.

With the `SCRAPE_DAY_HORIZON` guard protecting us from scraping permanently-broken URLs in perpetuity, we’re going to go ahead and retry scraping broken URLs.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. `yarn test` to make sure nothing breaks.
2. `yarn queue:jobs:run:cnn-portal-crawler` to make sure scraping still works.

## Deploy Notes
None.

## Related Issues
Resolves #337