### PR TITLE
Add build stages to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,17 @@ node_js:
   - 10
   - node
 
-deploy:
-  - provider: script
-    script:
-      bash scripts/deliver.sh -h $STAGING_SERVER -u $STAGING_SERVER_USER bash &&
-      ssh $STAGING_SERVER_USER@$STAGING_SERVER '
-        cd /var/www/tech-and-check-alerts &&
-        ./scripts/build.sh &&
-        ./scripts/start.sh'
-    on:
-      branch: "$STAGING_BRANCH"
+jobs:
+  include:
+    - stage: deploy
+      script: skip
+      deploy:
+        - provider: script
+          script:
+            bash scripts/deliver.sh -h $STAGING_SERVER -u $STAGING_SERVER_USER bash &&
+            ssh $STAGING_SERVER_USER@$STAGING_SERVER '
+              cd /var/www/tech-and-check-alerts &&
+              ./scripts/build.sh &&
+              ./scripts/start.sh'
+          on:
+            branch: "$STAGING_BRANCH"


### PR DESCRIPTION
We did not have deployment in its own build stage, which means deployment was happening for every set of tests.

## Description
This PR adds support for build stages in Travis to ensure that deployment only occurs once, and only after all tests pass.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
Unfortunately this can only be tested by opening a PR since it has to do with our CI service.

## Deploy Notes
No deployment necessary

## Related Issues
Resolves #336
