### PR TITLE
Add twitter account sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "queue:jobs:run:cnn-portal-crawler": "babel-node -- src/scripts/runCnnCrawler",
     "queue:jobs:run:twitter-scrape-initiation": "babel-node -- src/scripts/runTwitterScraper",
     "queue:jobs:run:known-speaker-scraper": "babel-node -- src/scripts/runKnownSpeakerScraper",
+    "queue:jobs:run:twitter-account-list-scraper": "babel-node -- src/scripts/runTwitterAccountListScraper",
     "mailer:send-test": "babel-node -- src/scripts/sendTestEmail",
     "newsletter:send-test": "babel-node -- src/scripts/sendTestNewsletter",
     "sandbox": "babel-node -- src/scripts/_sandbox",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "nodemon --watch src --exec yarn babel-node -- src/server/index.js",
     "build": "babel src -d lib",
     "lint": "./node_modules/.bin/eslint 'src/**/*.js'",
-    "pretest": "NODE_ENV=test yarn migrate",
+    "pretest": "NODE_ENV=test sequelize db:migrate:undo:all && NODE_ENV=test yarn migrate",
     "test": "jest",
     "migrate": "sequelize db:migrate",
     "queue:jobs:list": "babel-node -- src/scripts/listScheduledJobs",

--- a/src/scripts/runTwitterAccountListScraper.js
+++ b/src/scripts/runTwitterAccountListScraper.js
@@ -1,0 +1,20 @@
+import twitterAccountListScrapeInitiationQueueDict from '../server/queues/twitterAccountListScrapeInitiationQueue'
+import twitterAccountListScraperQueueDict from '../server/queues/twitterAccountListScraperQueue'
+
+import {
+  getQueueFromQueueDict,
+  startQueueProcessors,
+} from '../server/utils/queue'
+import logger from '../server/utils/logger'
+
+const twitterAccountListScrapeInitiationQueue = getQueueFromQueueDict(
+  twitterAccountListScrapeInitiationQueueDict,
+)
+twitterAccountListScrapeInitiationQueue.add()
+
+startQueueProcessors([
+  twitterAccountListScrapeInitiationQueueDict,
+  twitterAccountListScraperQueueDict,
+])
+
+logger.info('The twitter crawler is running; you will have to manually exit this process.')

--- a/src/server/constants.js
+++ b/src/server/constants.js
@@ -19,6 +19,15 @@ export const TWITTER_LIST_NAMES = {
   NORTH_CAROLINA: 'northCarolina',
 }
 
+// TODO - This should NOT be a constant. It should be DB driven. We are
+// using a constant temporarily since the dynamic newsletter functionality
+// will potentially change the way twitter lists are organized, and didn't
+// want to create migrations that will be almost immediately obsolete.
+export const TWITTER_LIST_GOOGLE_DOC_ID_MAP = {
+  [TWITTER_LIST_NAMES.NATIONAL]: '1gLkx2LK3yhS-glpsktWYNqBc9H2zsd7C6TvmgWjL5Kg',
+  [TWITTER_LIST_NAMES.NORTH_CAROLINA]: '1Z7grw_GQLNMtSVvkUtbXatly_JId7h3yVDX9BWyJetg',
+}
+
 export const CLAIMBUSTER_THRESHHOLD = 0.5
 
 export const CLAIMBUSTER_API_ROOT_URL = 'https://idir.uta.edu/claimbuster/api/v1'

--- a/src/server/migrations/20200406190114-add-twitter-account-unique-key.js
+++ b/src/server/migrations/20200406190114-add-twitter-account-unique-key.js
@@ -1,0 +1,20 @@
+import { runPromiseSequence } from '../utils'
+
+module.exports = {
+  up: queryInterface => queryInterface.sequelize
+    .transaction(t => runPromiseSequence([
+      () => queryInterface.addConstraint(
+        'twitter_accounts',
+        ['screen_name', 'list_name'],
+        {
+          type: 'unique',
+          name: 'screen_name_list_name',
+        },
+        { transaction: t },
+      ),
+    ])),
+  down: queryInterface => queryInterface.removeConstraint(
+    'twitter_accounts',
+    'screen_name_list_name',
+  ),
+}

--- a/src/server/models/TwitterAccount.js
+++ b/src/server/models/TwitterAccount.js
@@ -2,9 +2,15 @@ const Sequelize = require('sequelize')
 
 module.exports = (sequelize, DataTypes) => {
   const TwitterAccount = sequelize.define('TwitterAccount', {
-    screenName: DataTypes.STRING(128),
+    screenName: {
+      type: DataTypes.STRING(128),
+      unique: 'twitterAccountScreenNameListName',
+    },
     preferredDisplayName: DataTypes.STRING(512),
-    listName: DataTypes.STRING(128),
+    listName: {
+      type: DataTypes.STRING(128),
+      unique: 'twitterAccountScreenNameListName',
+    },
     isActive: DataTypes.BOOLEAN,
   }, {})
 

--- a/src/server/models/TwitterAccount.js
+++ b/src/server/models/TwitterAccount.js
@@ -45,5 +45,26 @@ module.exports = (sequelize, DataTypes) => {
   TwitterAccount.getActiveByListName = async listName => TwitterAccount
     .getActiveByListNames([listName])
 
+  TwitterAccount.deactivateTwitterAccountsByList = async (listName, transaction) => TwitterAccount
+    .update(
+      { isActive: false },
+      {
+        where: {
+          listName,
+        },
+        transaction,
+      },
+    )
+
+  TwitterAccount.createOrActivateTwitterAccounts = async (twitterAccounts, transaction) => Promise
+    .all(
+      twitterAccounts.map(
+        account => TwitterAccount.upsert(
+          account,
+          { transaction },
+        ),
+      ),
+    )
+
   return TwitterAccount
 }

--- a/src/server/queues/constants.js
+++ b/src/server/queues/constants.js
@@ -18,6 +18,7 @@ export const QueueNames = {
   },
   scraperQueues: {
     CNN_TRANSCRIPT_STATEMENT: 'cnnTranscriptStatementScraper',
+    TWITTER_ACCOUNT_LIST: 'twitterAccountStatementScraper',
     TWITTER_ACCOUNT_STATEMENT: 'twitterAccountStatementScraper',
     TWITTER_SCRAPE_INITITATION: 'twitterScrapeInitiation',
     KNOWN_SPEAKER: 'knownSpeakerScraper',

--- a/src/server/queues/constants.js
+++ b/src/server/queues/constants.js
@@ -20,6 +20,7 @@ export const QueueNames = {
     CNN_TRANSCRIPT_STATEMENT: 'cnnTranscriptStatementScraper',
     TWITTER_ACCOUNT_LIST: 'twitterAccountStatementScraper',
     TWITTER_ACCOUNT_STATEMENT: 'twitterAccountStatementScraper',
+    TWITTER_ACCOUNT_LIST_SCRAPE_INITITATION: 'twitterAccountListScrapeInitiation',
     TWITTER_SCRAPE_INITITATION: 'twitterScrapeInitiation',
     KNOWN_SPEAKER: 'knownSpeakerScraper',
   },

--- a/src/server/queues/twitterAccountListScrapeInitiationQueue/TwitterAccountListScrapeInitiationJobScheduler.js
+++ b/src/server/queues/twitterAccountListScrapeInitiationQueue/TwitterAccountListScrapeInitiationJobScheduler.js
@@ -1,0 +1,11 @@
+import TwitterAccountListScrapeInitiationQueueFactory from './TwitterAccountListScrapeInitiationQueueFactory'
+import AbstractJobScheduler from '../AbstractJobScheduler'
+import { Schedules } from '../constants'
+
+class TwitterAccountListScrapeInitiationJobScheduler extends AbstractJobScheduler {
+  getScheduleCron = () => Schedules.EVERY_DAY
+
+  getQueueFactory = () => new TwitterAccountListScrapeInitiationQueueFactory()
+}
+
+export default TwitterAccountListScrapeInitiationJobScheduler

--- a/src/server/queues/twitterAccountListScrapeInitiationQueue/TwitterAccountListScrapeInitiationQueueFactory.js
+++ b/src/server/queues/twitterAccountListScrapeInitiationQueue/TwitterAccountListScrapeInitiationQueueFactory.js
@@ -1,0 +1,10 @@
+import { QueueNames } from '../constants'
+import AbstractQueueFactory from '../AbstractQueueFactory'
+
+class TwitterAccountListScrapeInitiationQueueFactory extends AbstractQueueFactory {
+  getQueueName = () => QueueNames.scraperQueues.TWITTER_ACCOUNT_LIST_SCRAPE_INITITATION
+
+  getPathToProcessor = () => `${__dirname}/twitterAccountListScrapeInitiationJobProcessor.js`
+}
+
+export default TwitterAccountListScrapeInitiationQueueFactory

--- a/src/server/queues/twitterAccountListScrapeInitiationQueue/index.js
+++ b/src/server/queues/twitterAccountListScrapeInitiationQueue/index.js
@@ -1,0 +1,9 @@
+import TwitterAccountListScrapeInitiationQueueFactory from './TwitterAccountListScrapeInitiationQueueFactory'
+import TwitterAccountListScrapeInitiationJobScheduler from './TwitterAccountListScrapeInitiationJobScheduler'
+import twitterAccountListScrapeInitiationJobProcessor from './twitterAccountListScrapeInitiationJobProcessor'
+
+export default {
+  factory: new TwitterAccountListScrapeInitiationQueueFactory(),
+  scheduler: new TwitterAccountListScrapeInitiationJobScheduler(),
+  processor: twitterAccountListScrapeInitiationJobProcessor,
+}

--- a/src/server/queues/twitterAccountListScrapeInitiationQueue/twitterAccountListScrapeInitiationJobProcessor.js
+++ b/src/server/queues/twitterAccountListScrapeInitiationQueue/twitterAccountListScrapeInitiationJobProcessor.js
@@ -1,0 +1,17 @@
+import twitterAccountListScraperQueueDict from '../twitterAccountListScraperQueue'
+import { getQueueFromQueueDict } from '../../utils/queue'
+import { TWITTER_LIST_NAMES } from '../../constants'
+
+const twitterAccountListScraperQueue = getQueueFromQueueDict(
+  twitterAccountListScraperQueueDict,
+)
+
+const scrapeTwitterAccountList = listName => twitterAccountListScraperQueue.add({
+  listName,
+})
+
+export default async () => {
+  const listNames = Object.entries(TWITTER_LIST_NAMES).map(([, listName]) => listName)
+  listNames.forEach(scrapeTwitterAccountList)
+  return TWITTER_LIST_NAMES
+}

--- a/src/server/queues/twitterAccountListScraperQueue/TwitterAccountListScraperJobScheduler.js
+++ b/src/server/queues/twitterAccountListScraperQueue/TwitterAccountListScraperJobScheduler.js
@@ -1,0 +1,11 @@
+import TwitterAccountListScraperQueueFactory from './TwitterAccountListScraperQueueFactory'
+import AbstractJobScheduler from '../AbstractJobScheduler'
+import { Schedules } from '../constants'
+
+class TwitterAccountListScraperJobScheduler extends AbstractJobScheduler {
+  getScheduleCron = () => Schedules.NONE
+
+  getQueueFactory = () => new TwitterAccountListScraperQueueFactory()
+}
+
+export default TwitterAccountListScraperJobScheduler

--- a/src/server/queues/twitterAccountListScraperQueue/TwitterAccountListScraperQueueFactory.js
+++ b/src/server/queues/twitterAccountListScraperQueue/TwitterAccountListScraperQueueFactory.js
@@ -1,0 +1,10 @@
+import { QueueNames } from '../constants'
+import AbstractQueueFactory from '../AbstractQueueFactory'
+
+class TwitterAccountListScraperQueueFactory extends AbstractQueueFactory {
+  getQueueName = () => QueueNames.scraperQueues.TWITTER_ACCOUNT_LIST
+
+  getPathToProcessor = () => `${__dirname}/twitterAccountListScraperJobProcessor.js`
+}
+
+export default TwitterAccountListScraperQueueFactory

--- a/src/server/queues/twitterAccountListScraperQueue/index.js
+++ b/src/server/queues/twitterAccountListScraperQueue/index.js
@@ -1,0 +1,9 @@
+import TwitterAccountListScraperQueueFactory from './TwitterAccountListScraperQueueFactory'
+import TwitterAccountListScraperJobScheduler from './TwitterAccountListScraperJobScheduler'
+import twitterAccountListScraperJobProcessor from './twitterAccountListScraperJobProcessor'
+
+export default {
+  factory: new TwitterAccountListScraperQueueFactory(),
+  scheduler: new TwitterAccountListScraperJobScheduler(),
+  processor: twitterAccountListScraperJobProcessor,
+}

--- a/src/server/queues/twitterAccountListScraperQueue/twitterAccountListScraperJobProcessor.js
+++ b/src/server/queues/twitterAccountListScraperQueue/twitterAccountListScraperJobProcessor.js
@@ -1,0 +1,78 @@
+import GoogleSpreadsheetScraper from '../../workers/scrapers/GoogleSpreadsheetScraper'
+import logger from '../../utils/logger'
+import models from '../../models'
+import {
+  decorateObjects,
+  hasKey,
+} from '../../utils'
+import {
+  extractScreenName,
+  isTwitterScreenName,
+} from '../../utils/twitter'
+import { getDocumentIdByTwitterListName } from '../../utils/google'
+
+const {
+  sequelize,
+  TwitterAccount,
+} = models
+
+const isTwitterDisplayNameColumn = columnName => /twitter_\d+/.test(columnName)
+  || columnName === 'twitter_%d'
+
+const extractTwitterScreenNameColumnsFromRow = row => Object.keys(row)
+  .filter(isTwitterDisplayNameColumn)
+
+const hasAtLeastOneTwitterScreenNameColumn = row => (
+  extractTwitterScreenNameColumnsFromRow(row).length >= 1
+)
+
+const isValidTwitterAccountRow = row => (
+  hasKey(row, 'display_name')
+  && hasAtLeastOneTwitterScreenNameColumn(row)
+)
+
+const extractTwitterAccountsFromRow = (row, screenNameColumns) => {
+  const screenNames = screenNameColumns
+    .map(columnName => extractScreenName(row[columnName]))
+    .filter(isTwitterScreenName)
+  const twitterAccounts = screenNames.map(screenName => ({
+    screenName,
+    preferredDisplayName: row.display_name,
+  }))
+  return twitterAccounts
+}
+
+const extractTwitterAccountsFromRows = (rows, screenNameColumns) => rows
+  .filter(isValidTwitterAccountRow)
+  .map(row => extractTwitterAccountsFromRow(row, screenNameColumns))
+  .reduce(
+    (accumulator, twitterAccounts) => accumulator.concat(twitterAccounts),
+    [],
+  )
+
+export default async (job) => {
+  const {
+    data: {
+      listName,
+    },
+  } = job
+
+  const documentId = getDocumentIdByTwitterListName(listName)
+  logger.info(`Syncing twitter accounts for "${listName}" from Google doc: ${documentId}`)
+  const scraper = new GoogleSpreadsheetScraper(documentId, true)
+  const rows = await scraper.run()
+  const screenNameColumns = extractTwitterScreenNameColumnsFromRow(rows[0] || {})
+  const twitterAccounts = extractTwitterAccountsFromRows(rows, screenNameColumns)
+  const decoratedTwitterAccounts = decorateObjects(
+    twitterAccounts,
+    {
+      listName,
+      isActive: true,
+    },
+  )
+  logger.info(`Total accounts found: ${decoratedTwitterAccounts.length}`)
+  return sequelize.transaction(async (transaction) => {
+    await TwitterAccount.deactivateTwitterAccountsByList(listName, transaction)
+    return TwitterAccount.createOrActivateTwitterAccounts(decoratedTwitterAccounts, transaction)
+  })
+}

--- a/src/server/utils/__test__/index.test.js
+++ b/src/server/utils/__test__/index.test.js
@@ -1,4 +1,5 @@
 import {
+  decorateObjects,
   isTestEnv,
   isDevelopmentEnv,
   isProductionEnv,
@@ -36,6 +37,23 @@ describe('utils/index', () => {
       expect(hasVisibleContent()).toBe(false)
       expect(hasVisibleContent('')).toBe(false)
       expect(hasVisibleContent(' ')).toBe(false)
+    })
+  })
+  describe('#decorateObjects', () => {
+    it('Should assign the new values to all objects', () => {
+      const originalObjects = [
+        { a: 1, b: 2 },
+        { a: 3, b: 4 },
+      ]
+      const decorator = {
+        c: 5,
+      }
+      const modifiedObjects = decorateObjects(originalObjects, decorator)
+      expect(modifiedObjects).toHaveLength(2)
+      expect(modifiedObjects[0]).toHaveProperty('c')
+      expect(modifiedObjects[0].c).toEqual(5)
+      expect(modifiedObjects[1]).toHaveProperty('c')
+      expect(modifiedObjects[1].c).toEqual(5)
     })
   })
 })

--- a/src/server/utils/__test__/twitter.test.js
+++ b/src/server/utils/__test__/twitter.test.js
@@ -8,6 +8,7 @@ import {
   getSourceFromTweet,
   getTextFromTweet,
   getSpeakerAffiliationFromTweet,
+  extractScreenName,
   getScreenNameHash,
   getBestName,
   getScreenNamesFromStatements,
@@ -92,6 +93,26 @@ describe('getSpeakerAffiliationFromTweet', () => {
   it('Should pull the user description from a tweet', () => {
     expect(getSpeakerAffiliationFromTweet(tweet))
       .toEqual(tweet.user.description)
+  })
+})
+describe('extractScreenName', () => {
+  it('Should extract screen names', () => {
+    expect(extractScreenName('https://www.twitter.com/SenatorBurr')).toEqual('SenatorBurr')
+    expect(extractScreenName('http://wwww.twitter.com/jeffnc2')).toEqual('jeffnc2')
+    expect(extractScreenName('http://twitter.com/CalforNC')).toEqual('CalforNC')
+    expect(extractScreenName('http://twitter.com/CalforNC?q=15')).toEqual('CalforNC')
+    expect(extractScreenName('@slifty')).toEqual('slifty')
+    expect(extractScreenName('@slifty_again')).toEqual('slifty_again')
+    expect(extractScreenName('http://twitter.com/CalforNC?q=15')).toEqual('CalforNC')
+    expect(extractScreenName('twitter.com/cabgop')).toEqual('cabgop')
+    expect(extractScreenName('https://twitter.com/@JudgeHeathNC')).toEqual('JudgeHeathNC')
+  })
+  it('Should not extract screen names from invalid strings', () => {
+    expect(extractScreenName('http://haywooddemocrats.org/slifty')).toEqual('')
+  })
+  it('Should not extract invalid screen names', () => {
+    expect(extractScreenName('---')).toEqual('')
+    expect(extractScreenName('@slifty_but_way_too_long_for_twitter')).toEqual('')
   })
 })
 describe('getScreenNameHash', () => {

--- a/src/server/utils/google.js
+++ b/src/server/utils/google.js
@@ -1,5 +1,5 @@
 import parse from 'csv-parse'
-import { TWITTER_LIST_DOCUMENT_MAP } from '../constants'
+import { TWITTER_LIST_GOOGLE_DOC_ID_MAP } from '../constants'
 
 export const getSpreadsheetCsvUrl = spreadsheetId => `https://docs.google.com/spreadsheets/d/${spreadsheetId}/export?format=csv`
 
@@ -32,4 +32,4 @@ export const parseCsvString = async (googleCsvString, columnHeaders = false) => 
  * @param  {String} listName The twitter list name
  * @return {String}          The associated google doc ID
  */
-export const getDocumentIdByTwitterListName = listName => TWITTER_LIST_DOCUMENT_MAP[listName] || ''
+export const getDocumentIdByTwitterListName = listName => TWITTER_LIST_GOOGLE_DOC_ID_MAP[listName] || ''

--- a/src/server/utils/google.js
+++ b/src/server/utils/google.js
@@ -1,4 +1,5 @@
 import parse from 'csv-parse'
+import { TWITTER_LIST_DOCUMENT_MAP } from '../constants'
 
 export const getSpreadsheetCsvUrl = spreadsheetId => `https://docs.google.com/spreadsheets/d/${spreadsheetId}/export?format=csv`
 
@@ -20,3 +21,15 @@ export const parseCsvString = async (googleCsvString, columnHeaders = false) => 
       .on('end', () => resolve(output))
   })
 )
+
+/**
+ * This method is strange, because ultimately this should all be database driven
+ * We should quickly implement a table for this mapping.
+ *
+ * This method takes a twitter list name (which may be deprecated as a concept soon) and returns
+ * the google document ID that contains the content of that list.
+ *
+ * @param  {String} listName The twitter list name
+ * @return {String}          The associated google doc ID
+ */
+export const getDocumentIdByTwitterListName = listName => TWITTER_LIST_DOCUMENT_MAP[listName] || ''

--- a/src/server/utils/index.js
+++ b/src/server/utils/index.js
@@ -40,3 +40,12 @@ export const squish = string => string.replace(/\s+/g, ' ')
  * @return {Boolean}     True if it has non-whitespace content, else false
  */
 export const hasVisibleContent = text => !!text && text.replace(/\s/g, '').length > 0
+
+/**
+ * Assigns a common set of properties to all objects in an array.
+ *
+ * @param  {Array[Object]} arr        The array of objects to be decorated
+ * @param  {Object}        properties The properties to be assigned to each object
+ * @return {Array[Object]}            The array of decorated objects
+ */
+export const decorateObjects = (arr, properties) => arr.map(item => Object.assign(item, properties))

--- a/src/server/utils/twitter.js
+++ b/src/server/utils/twitter.js
@@ -43,6 +43,25 @@ export const extractStatementsFromTweets = tweets => tweets.map(tweet => ({
 }))
 
 /**
+ * Attempts to extract a twitter screen name from a string.
+ *
+ * The string could be a Twitter URL, an @handle, or just a handle.
+ *
+ * @param  {String} str The string containing a twitter screen name.
+ * @return {String}     The extracted screen name, hopefully
+ */
+export const extractScreenName = (str) => {
+  const cleanedInput = str
+    .replace(/^@/, '')
+    .replace(/(https?:\/\/(.*\.)?)?twitter\.com\/@?(\w+)(\W.*)?/, '$3')
+
+  if (isTwitterScreenName(cleanedInput)) {
+    return cleanedInput
+  }
+  return ''
+}
+
+/**
  * Converts a screen name to a form that can reliably be used as a dict key.
  *
  * @param  {String} screenName The screen name you want to hash


### PR DESCRIPTION
## Description
This PR adds two new queues in order to create the regular synchronization of twitter accounts with a google doc.

The first queue will scrape the document associated with a list, disable twitter accounts associated with that list, and re-enable (or add) any accounts that are on the list according to the scrape.

The second queue is the initiation queue which starts jobs in the first queue for each registered twitter list.

A critical note: this PR adds calculated tech debt.  Specifically, we are storing the google docs as constants.  This is NOT an appropriate use of a constant, but since we are about to change the way twitter lists and newsletters are managed in our system we felt that this was the least onerous approach.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. `yarn test`

## Deploy Notes
- `yarn migrate`

## Related Issues
Resolves #229 
Related to #255 
