### PR TITLE
Hotfix list scraper

### DIFF
--- a/src/server/queues/__test__/constants.test.js
+++ b/src/server/queues/__test__/constants.test.js
@@ -1,0 +1,14 @@
+import { QueueNames } from '../constants'
+
+describe('queue constants', () => {
+  describe('QueueNames', () => {
+    it('should not have any repeated queue names', () => {
+      const allQueueNames = Object.values(QueueNames).reduce(
+        (aggregate, bucket) => aggregate.concat(Object.values(bucket)),
+        [],
+      ).sort()
+      const uniqueQueueNames = Array.from(new Set(allQueueNames))
+      expect(uniqueQueueNames).toEqual(allQueueNames)
+    })
+  })
+})

--- a/src/server/queues/constants.js
+++ b/src/server/queues/constants.js
@@ -18,7 +18,7 @@ export const QueueNames = {
   },
   scraperQueues: {
     CNN_TRANSCRIPT_STATEMENT: 'cnnTranscriptStatementScraper',
-    TWITTER_ACCOUNT_LIST: 'twitterAccountStatementScraper',
+    TWITTER_ACCOUNT_LIST: 'twitterAccountListScraper',
     TWITTER_ACCOUNT_STATEMENT: 'twitterAccountStatementScraper',
     TWITTER_ACCOUNT_LIST_SCRAPE_INITITATION: 'twitterAccountListScrapeInitiation',
     TWITTER_SCRAPE_INITITATION: 'twitterScrapeInitiation',

--- a/src/server/queues/twitterAccountListScraperQueue/twitterAccountListScraperJobProcessor.js
+++ b/src/server/queues/twitterAccountListScraperQueue/twitterAccountListScraperJobProcessor.js
@@ -17,7 +17,6 @@ const {
 } = models
 
 const isTwitterDisplayNameColumn = columnName => /twitter_\d+/.test(columnName)
-  || columnName === 'twitter_%d'
 
 const extractTwitterScreenNameColumnsFromRow = row => Object.keys(row)
   .filter(isTwitterDisplayNameColumn)


### PR DESCRIPTION
## Description
This PR fixes a major issue with the twitter account list scraper where it was being triggered every time a twitter *account* was scraped (so, thousands of times a day).

NOTE: this did not impact production, since we were still in QA for this feature (it did not make it past staging yet)

This PR also makes an inconsequential tweak related to accepted column names.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #361
Resolves #362 
Resolves #357 
