### PR TITLE
Move Twitter lists to the database

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,9 +4,9 @@
 # NODE_ENV=
 
 # PostgreSQL connection settings
-DATABASE_URL_PRODUCTION=postgresql://username:password@localhost/dbname
-DATABASE_URL_DEVELOPMENT=postgresql://username:password@localhost/dbname
-DATABASE_URL_TEST=postgresql://username:password@localhost/dbname
+DATABASE_URL_PRODUCTION=postgres://username:password@localhost/dbname
+DATABASE_URL_DEVELOPMENT=postgres://username:password@localhost/dbname
+DATABASE_URL_TEST=postgres://username:password@localhost/dbname
 
 # Redis connection settings
 REDIS_URL=redis://127.0.0.1:6379

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "nodemon --watch src --exec yarn babel-node -- src/server/index.js",
     "build": "babel src -d lib",
     "lint": "./node_modules/.bin/eslint 'src/**/*.js'",
-    "pretest": "NODE_ENV=test sequelize db:migrate:undo:all && NODE_ENV=test yarn migrate",
+    "pretest": "NODE_ENV=test sequelize db:drop && NODE_ENV=test sequelize db:create && NODE_ENV=test yarn migrate",
     "test": "jest",
     "migrate": "sequelize db:migrate",
     "queue:jobs:list": "babel-node -- src/scripts/listScheduledJobs",

--- a/src/server/constants.js
+++ b/src/server/constants.js
@@ -19,15 +19,6 @@ export const TWITTER_LIST_NAMES = {
   NORTH_CAROLINA: 'northCarolina',
 }
 
-// TODO - This should NOT be a constant. It should be DB driven. We are
-// using a constant temporarily since the dynamic newsletter functionality
-// will potentially change the way twitter lists are organized, and didn't
-// want to create migrations that will be almost immediately obsolete.
-export const TWITTER_LIST_GOOGLE_DOC_ID_MAP = {
-  [TWITTER_LIST_NAMES.NATIONAL]: '1gLkx2LK3yhS-glpsktWYNqBc9H2zsd7C6TvmgWjL5Kg',
-  [TWITTER_LIST_NAMES.NORTH_CAROLINA]: '1Z7grw_GQLNMtSVvkUtbXatly_JId7h3yVDX9BWyJetg',
-}
-
 export const CLAIMBUSTER_THRESHHOLD = 0.5
 
 export const CLAIMBUSTER_API_ROOT_URL = 'https://idir.uta.edu/claimbuster/api/v1'

--- a/src/server/migrations/20200406190114-add-twitter-account-unique-key.js
+++ b/src/server/migrations/20200406190114-add-twitter-account-unique-key.js
@@ -9,8 +9,8 @@ module.exports = {
         {
           type: 'unique',
           name: 'screen_name_list_name',
+          transaction: t,
         },
-        { transaction: t },
       ),
     ])),
   down: queryInterface => queryInterface.removeConstraint(

--- a/src/server/migrations/20200507181156-create-twitter-account-lists.js
+++ b/src/server/migrations/20200507181156-create-twitter-account-lists.js
@@ -1,0 +1,34 @@
+import { runPromiseSequence } from '../utils'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.sequelize
+    .transaction(t => runPromiseSequence([
+      () => queryInterface.createTable(
+        'twitter_account_lists',
+        {
+          id: {
+            allowNull: false,
+            autoIncrement: true,
+            primaryKey: true,
+            type: Sequelize.INTEGER,
+          },
+          name: {
+            type: Sequelize.STRING,
+          },
+          google_doc_id: {
+            type: Sequelize.STRING,
+          },
+          created_at: {
+            allowNull: false,
+            type: Sequelize.DATE,
+          },
+          updated_at: {
+            allowNull: false,
+            type: Sequelize.DATE,
+          },
+        },
+        { transaction: t },
+      ),
+    ])),
+  down: queryInterface => queryInterface.dropTable('twitter_account_lists'),
+}

--- a/src/server/migrations/20200531192735-refactor-twitter-account-list-association.js
+++ b/src/server/migrations/20200531192735-refactor-twitter-account-list-association.js
@@ -1,0 +1,81 @@
+import { runPromiseSequence } from '../utils'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.sequelize
+    .transaction(transaction => runPromiseSequence([
+      () => queryInterface.addColumn(
+        'twitter_accounts',
+        'twitter_account_list_id',
+        {
+          type: Sequelize.INTEGER,
+          references: {
+            model: 'twitter_account_lists',
+            key: 'id',
+          },
+        },
+        { transaction },
+      ),
+      () => queryInterface.sequelize.query(
+        `
+        UPDATE twitter_accounts
+        SET    twitter_account_list_id = (
+          SELECT twitter_account_lists.id
+          FROM   twitter_account_lists
+          WHERE  twitter_account_lists.name = twitter_accounts.list_name
+          LIMIT  1
+        )`,
+        { transaction },
+      ),
+      () => queryInterface.removeColumn(
+        'twitter_accounts',
+        'list_name',
+        { transaction },
+      ),
+      () => queryInterface.addConstraint(
+        'twitter_accounts',
+        ['screen_name', 'twitter_account_list_id'],
+        {
+          type: 'unique',
+          name: 'screen_name_twitter_account_list_id',
+          transaction,
+        },
+      ),
+    ])),
+
+  down: (queryInterface, Sequelize) => queryInterface.sequelize
+    .transaction(transaction => runPromiseSequence([
+      () => queryInterface.addColumn(
+        'twitter_accounts',
+        'list_name',
+        {
+          type: Sequelize.STRING(128),
+        },
+        { transaction },
+      ),
+      () => queryInterface.addConstraint(
+        'twitter_accounts',
+        ['screen_name', 'list_name'],
+        {
+          type: 'unique',
+          name: 'screen_name_list_name',
+          transaction,
+        },
+      ),
+      () => queryInterface.sequelize.query(
+        `
+        UPDATE twitter_accounts
+        SET    list_name = (
+          SELECT twitter_account_lists.name
+          FROM   twitter_account_lists
+          WHERE  twitter_account_lists.id = twitter_accounts.twitter_account_list_id
+          LIMIT  1
+        )`,
+        { transaction },
+      ),
+      () => queryInterface.removeColumn(
+        'twitter_accounts',
+        'twitter_account_list_id',
+        { transaction },
+      ),
+    ])),
+}

--- a/src/server/models/TwitterAccountList.js
+++ b/src/server/models/TwitterAccountList.js
@@ -1,0 +1,11 @@
+module.exports = (sequelize, DataTypes) => {
+  const TwitterAccountList = sequelize.define('TwitterAccountList', {
+    name: DataTypes.STRING,
+    googleDocId: DataTypes.STRING
+  }, {})
+
+  TwitterAccountList.associate = (models) => {
+  }
+
+  return TwitterAccountList
+}

--- a/src/server/models/TwitterAccountList.js
+++ b/src/server/models/TwitterAccountList.js
@@ -1,10 +1,11 @@
 module.exports = (sequelize, DataTypes) => {
   const TwitterAccountList = sequelize.define('TwitterAccountList', {
     name: DataTypes.STRING,
-    googleDocId: DataTypes.STRING
+    googleDocId: DataTypes.STRING,
   }, {})
 
   TwitterAccountList.associate = (models) => {
+    TwitterAccountList.hasMany(models.TwitterAccount)
   }
 
   return TwitterAccountList

--- a/src/server/queues/twitterAccountListScrapeInitiationQueue/twitterAccountListScrapeInitiationJobProcessor.js
+++ b/src/server/queues/twitterAccountListScrapeInitiationQueue/twitterAccountListScrapeInitiationJobProcessor.js
@@ -1,17 +1,19 @@
 import twitterAccountListScraperQueueDict from '../twitterAccountListScraperQueue'
 import { getQueueFromQueueDict } from '../../utils/queue'
-import { TWITTER_LIST_NAMES } from '../../constants'
+import models from '../../models'
+
+const { TwitterAccountList } = models
 
 const twitterAccountListScraperQueue = getQueueFromQueueDict(
   twitterAccountListScraperQueueDict,
 )
 
-const scrapeTwitterAccountList = listName => twitterAccountListScraperQueue.add({
-  listName,
+const scrapeTwitterAccountList = twitterAccountList => twitterAccountListScraperQueue.add({
+  twitterAccountListId: twitterAccountList.id,
 })
 
 export default async () => {
-  const listNames = Object.entries(TWITTER_LIST_NAMES).map(([, listName]) => listName)
-  listNames.forEach(scrapeTwitterAccountList)
-  return TWITTER_LIST_NAMES
+  const twitterAccountLists = await TwitterAccountList.findAll()
+  twitterAccountLists.forEach(scrapeTwitterAccountList)
+  return twitterAccountLists
 }

--- a/src/server/utils/google.js
+++ b/src/server/utils/google.js
@@ -1,5 +1,4 @@
 import parse from 'csv-parse'
-import { TWITTER_LIST_GOOGLE_DOC_ID_MAP } from '../constants'
 
 export const getSpreadsheetCsvUrl = spreadsheetId => `https://docs.google.com/spreadsheets/d/${spreadsheetId}/export?format=csv`
 
@@ -21,15 +20,3 @@ export const parseCsvString = async (googleCsvString, columnHeaders = false) => 
       .on('end', () => resolve(output))
   })
 )
-
-/**
- * This method is strange, because ultimately this should all be database driven
- * We should quickly implement a table for this mapping.
- *
- * This method takes a twitter list name (which may be deprecated as a concept soon) and returns
- * the google document ID that contains the content of that list.
- *
- * @param  {String} listName The twitter list name
- * @return {String}          The associated google doc ID
- */
-export const getDocumentIdByTwitterListName = listName => TWITTER_LIST_GOOGLE_DOC_ID_MAP[listName] || ''

--- a/src/server/utils/newsletters.js
+++ b/src/server/utils/newsletters.js
@@ -54,23 +54,3 @@ export const getTwitterScreenNamesByListName = async listName => (
   TwitterAccount.getActiveByListName(listName)
     .then(accounts => accounts.map(account => account.screenName))
 )
-
-/**
- * Gets the screen names for a given array of Twitter lists.
- *
- * @param  {Array<String>} listNames The Twitter lists we want screen names for
- * @return {Object}                  An array of screen names for each list, organized into an
- *                                   object keyed by list name
- */
-export const getTwitterScreenNamesByListNames = async listNames => (
-  TwitterAccount.getActiveByListNames(listNames)
-    .then(accounts => accounts.reduce((lists, account) => {
-      if (hasKey(lists, account.listName)) {
-        lists[account.listName].push(account.screenName)
-      } else {
-        // eslint-disable-next-line no-param-reassign
-        lists[account.listName] = [account.screenName]
-      }
-      return lists
-    }, {}))
-)


### PR DESCRIPTION
## Description
This PR adds the database concept of TwitterAccountLists, which replace the previous constant-driven twitter account list architecture.

It updates the twitter account list sync logic to use the database.

It is a draft because it does not yet update the newsletter generation to reflect these changes.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. Update your environment variables so that the DB urls start with `postgres://` instead of `postgresql://`
2. Wipe out your local DB if I'm being honest
3. re-run migrate
4. Add two rows to `twitter_account_lists`: 

```
0 | national      | 1gLkx2LK3yhS-glpsktWYNqBc9H2zsd7C6TvmgWjL5Kg | 2020-06-11 11:58:45.171008-04 | 2020-06-11 11:58:45.171008-04
  1 | northCarolina | 1Z7grw_GQLNMtSVvkUtbXatly_JId7h3yVDX9BWyJetg | 2020-06-11 11:59:13.735023-04 | 2020-06-11 11:59:13.735023-04
```

5. Try running the scraper and all that jazz as you normally would.

## Deploy Notes
- `yarn migrate`
- Update .env variables so that the DB urls start with `postgres://` instead of `postgresql://`
- Add two rows to `twitter_account_lists` (see previous section with data)

## Related Issues
Resolves #364 
Resolves #368 
